### PR TITLE
Add `BUILDKITE` env variable to list of exported env vars

### DIFF
--- a/Sources/hostmgr/commands/generate/GenerateBuildkiteJobScript.swift
+++ b/Sources/hostmgr/commands/generate/GenerateBuildkiteJobScript.swift
@@ -32,6 +32,7 @@ struct GenerateBuildkiteJobScript: ParsableCommand {
         // See https://buildkite.com/docs/pipelines/environment-variables for
         // and up-to-date list of environment variables that Buildkite exports
         let copyableExports = [
+            "BUILDKITE",
             "BUILDKITE_JOB_ID",
             "BUILDKITE_REPO",
             "BUILDKITE_COMMIT",


### PR DESCRIPTION
_What it says in the title_ 😅

Tools like Danger [use it](https://github.com/danger/danger/blob/eca19719d3e585fe1cc46bc5377f9aa955ebf609/lib/danger/ci_source/buildkite.rb#L30-L32) to determine whether they're running on Buildkite.