### PR TITLE
Add the ability to force an immediate sync

### DIFF
--- a/Sources/hostmgr/commands/sync/SyncAuthorizedKeysCommand.swift
+++ b/Sources/hostmgr/commands/sync/SyncAuthorizedKeysCommand.swift
@@ -58,12 +58,12 @@ struct SyncAuthorizedKeysTask {
         self.destination = destination
     }
 
-    func run() throws {
+    func run(force: Bool = false) throws {
         let state = State.get()
 
         logger.debug("Downloading file from s3://\(bucket)/\(key) in \(region) to \(destination)")
 
-        guard state.shouldRun else {
+        guard state.shouldRun && force else {
             print("This job is not scheduled to run until \(state.nextRunTime)")
             return
         }

--- a/Sources/hostmgr/commands/sync/SyncVMImagesCommand.swift
+++ b/Sources/hostmgr/commands/sync/SyncVMImagesCommand.swift
@@ -18,7 +18,7 @@ struct SyncVMImagesCommand: ParsableCommand {
 
 struct SyncVMImagesTask {
 
-    func run() throws {
+    func run(force: Bool = false) throws {
         var state = State.get()
 
         guard !state.isRunning else {
@@ -26,7 +26,7 @@ struct SyncVMImagesTask {
             return
         }
 
-        guard state.shouldRun else {
+        guard state.shouldRun && force else {
             print("This job is not scheduled to run until \(state.nextRunTime)")
             return
         }


### PR DESCRIPTION
This allows us to ensure that by the time Ansible finishes running, the remote machine has everything it needs.