### PR TITLE
add BUILDKITE_LABEL and BUILDKITE_AGENT_NAME env vars to VM

### DIFF
--- a/Sources/hostmgr/commands/generate/GenerateBuildkiteJobScript.swift
+++ b/Sources/hostmgr/commands/generate/GenerateBuildkiteJobScript.swift
@@ -59,6 +59,8 @@ struct GenerateBuildkiteJobScript: ParsableCommand {
             "BUILDKITE_AGENT_DEBUG",
             "BUILDKITE_AGENT_PROFILE",
             "BUILDKITE_BOOTSTRAP_PHASES",
+            "BUILDKITE_LABEL",
+            "BUILDKITE_AGENT_NAME",
 
             /// These ones aren't printed as part of the default list – we're copying them so that `bootstrap` works
             "BUILDKITE_AGENT_ACCESS_TOKEN",


### PR DESCRIPTION
While working on a PR for the s3 caching plugin, I noticed these two variables weren't being passed to the VM.  I believe this change should make them available in the VM. 

https://github.com/Automattic/git-s3-cache-buildkite-plugin/pull/4

@jkmassel does this change just need to get merged? or does it need a manual deploy? 