### PR TITLE
Add `FASTLANE_HIDE_PLUGINS_TABLE` to the env vars we pass along

### DIFF
--- a/Sources/hostmgr/commands/generate/GenerateBuildkiteJobScript.swift
+++ b/Sources/hostmgr/commands/generate/GenerateBuildkiteJobScript.swift
@@ -95,6 +95,10 @@ struct GenerateBuildkiteJobScript: ParsableCommand {
 
             /// Used by the S3 Git Mirror plugin
             "GIT_MIRROR_SERVER_ROOT": "http://\(try getIpAddress()):\( Configuration.shared.gitMirrorPort)",
+
+            /// If the project uses Fastlane, we don't want it to print the plugins table.
+            /// Our release toolkit plugin defines many actions and would pollute the logs with many lines of dashes
+            "FASTLANE_HIDE_PLUGINS_TABLE": "1",
         ]
         .merging(copyableExports, uniquingKeysWith: { lhs, rhs in lhs })
         .compactMapValues { $0 }


### PR DESCRIPTION
Fastlane 2.205.0 introduced [an env var to stop printing the plugins table](https://github.com/fastlane/fastlane/blob/3b4106039b518564f97aca3505180ef4ea03a2ae/fastlane_core/README.md#output-environment-variables):

![image](https://user-images.githubusercontent.com/1218433/171339138-f711d314-8a13-477d-bd38-fe72a7c0fd1b.png)

That's basically useless information in CI, and it would be useful to remove it to make the logs easier to scroll.

Initially, I tried setting the value in the `pipeline.yml` `*common_env` key, but that didn't work. I had forgotten about our environment channelling here.

All in all, I think it's actually preferable to set the value here, so that we don't have to duplicate the setting across all our pipelines.

I considered adding exports for `FASTLANE_HIDE_CHANGELOG` and `FASTLANE_SKIP_UPDATE_CHECK`, but it looks like neither of those outputs are printed anyways 🤔 I'm not sure if that's just something Fastlane doesn't do in CI or we have them set elsewhere? It was hard, but I didn't go down this rabbit hole because it's a low ROI thing to investigate.