### PR TITLE
Fix local VM image listing

### DIFF
--- a/Sources/hostmgr/commands/vm/VMDelete.swift
+++ b/Sources/hostmgr/commands/vm/VMDelete.swift
@@ -24,7 +24,13 @@ struct VMDeleteCommand: ParsableCommand {
         try virtualMachine?.delete()
 
         if let prefix = startingWith {
-            try VMLocalImageManager().lookupVMsBy(prefix: prefix).forEach { try $0.delete() }
+            try lookupVMsBy(prefix: prefix).forEach { try $0.delete() }
         }
+    }
+
+    func lookupVMsBy(prefix: String) throws -> [VMProtocol] {
+        return try Parallels()
+            .lookupAllVMs()
+            .filter { $0.name.hasPrefix(prefix) }
     }
 }

--- a/Sources/hostmgr/commands/vm/image/local/VMLocalImageList.swift
+++ b/Sources/hostmgr/commands/vm/image/local/VMLocalImageList.swift
@@ -5,11 +5,14 @@ struct VMLocalImageListCommand: ParsableCommand {
 
     static let configuration = CommandConfiguration(
         commandName: "list",
-        abstract: "List available VM images"
+        abstract: "List VM images that exist on disk on the local machine"
     )
 
     func run() throws {
-        let images =  try VMLocalImageManager().list()
-        images.sorted().forEach { print("\($0)") }
+        try VMLocalImageManager()
+            .listImageFilePaths()
+            .map { $0.lastPathComponent }
+            .sorted()
+            .forEach { print("\($0)") }
     }
 }

--- a/Sources/hostmgr/commands/vm/image/remote/VMRemoteImageList.swift
+++ b/Sources/hostmgr/commands/vm/image/remote/VMRemoteImageList.swift
@@ -6,7 +6,7 @@ struct VMRemoteImageListCommand: ParsableCommand {
 
     static let configuration = CommandConfiguration(
         commandName: "list",
-        abstract: "List available VM images"
+        abstract: "List VM images that are available for download from the server"
     )
 
     func run() throws {

--- a/Sources/hostmgr/helpers/Foundation.swift
+++ b/Sources/hostmgr/helpers/Foundation.swift
@@ -22,6 +22,10 @@ extension FileManager {
     func subpaths(at url: URL) -> [String] {
         self.subpaths(atPath: url.path) ?? []
     }
+
+    func displayName(at url: URL) -> String {
+        displayName(atPath: url.path)
+    }
 }
 
 extension URL: ExpressibleByArgument {


### PR DESCRIPTION
Fixes local VM image listing – it was relying on Parallels, not on the contents on disk.

**To Test:**
1. Run `swift run hostmgr vm image local list` from the `hostmgr` root directory
2. It should list files on disk (even if Parallels doesn't know about them – to test this, you could throw a random file in `/usr/local/var/vm-images` on an Intel Mac or `/opt/homebrew/var/vm-images` on an Apple Silicon Mac and see that it shows up)