### PR TITLE
Fix `hostmgr --version` command

### DIFF
--- a/Sources/hostmgr/main.swift
+++ b/Sources/hostmgr/main.swift
@@ -23,7 +23,7 @@ struct Hostmgr: ParsableCommand {
     var version: Bool = false
 
     func run() throws {
-        if version {
+        guard version == false else {
             print(appVersion)
             return
         }

--- a/Sources/hostmgr/main.swift
+++ b/Sources/hostmgr/main.swift
@@ -3,7 +3,7 @@ import SotoS3
 import Logging
 import libhostmgr
 
-struct HostMgr: ParsableCommand {
+struct Hostmgr: ParsableCommand {
 
     private var appVersion = "0.14.0"
 
@@ -40,7 +40,7 @@ struct HostMgr: ParsableCommand {
 }
 
 initializeLoggingSystem()
-HostMgr.main()
+Hostmgr.main()
 
 struct SetCommand: ParsableCommand {
     static let configuration = CommandConfiguration(

--- a/Sources/hostmgr/main.swift
+++ b/Sources/hostmgr/main.swift
@@ -23,6 +23,11 @@ struct HostMgr: ParsableCommand {
     var version: Bool = false
 
     func run() throws {
+        if version {
+            print(appVersion)
+            return
+        }
+
         logger.debug("Starting Up")
 
         guard Configuration.isValid else {
@@ -30,11 +35,7 @@ struct HostMgr: ParsableCommand {
             throw ExitCode(1)
         }
 
-        if version {
-            print(appVersion)
-        } else {
-            throw CleanExit.helpRequest(self)
-        }
+        throw CleanExit.helpRequest(self)
     }
 }
 


### PR DESCRIPTION
## Changes

This PR fixes two minor issues:
1. `hostmgr --version` doesn't print the version.
```
$ hostmgr --version
2022-08-17T16:56:38+1200 debug com.automattic.hostmgr : Starting Up
Invalid configuration – exiting
```
2. argument-parser incorrectly assumes the command is 'host-mgr', which is derived from the type name `HostMgr`. 
```
$ hostmgr --help
OVERVIEW: A utility for managing VM hosts

USAGE: host-mgr [--version] <subcommand>

...
```

## Test instructions
Checkout this PR locally and run the following command.
```
swift build
swift run --skip-build hostmgr --version # Output should be '0.14.0'
swift run --skip-build hostmgr --help # Output shows 'hostmgr' as the command, not 'host-mgr'
```