### PR TITLE
Set the timeout of S3 clients to 30 minutes

### DIFF
--- a/Sources/hostmgr/helpers/S3.swift
+++ b/Sources/hostmgr/helpers/S3.swift
@@ -125,7 +125,8 @@ struct S3Manager {
         for bucket: String,
         in region: Region
     ) throws -> S3 {
-        let s3Client = S3(client: aws, region: region)
+        let timeout = TimeAmount.minutes(30)
+        let s3Client = S3(client: aws, region: region, timeout: timeout)
 
         guard Configuration.shared.allowAWSAcceleratedTransfer else {
             logger.log(level: .info, "Using Standard S3 Download")
@@ -139,7 +140,7 @@ struct S3Manager {
 
         logger.log(level: .info, "Using Accelerated S3 Download")
 
-        return S3(client: aws, region: region, endpoint: "https://\(bucket).s3-accelerate.amazonaws.com")
+        return S3(client: aws, region: region, endpoint: "https://\(bucket).s3-accelerate.amazonaws.com", timeout: timeout)
     }
 
     private func bucketTransferAccelerationIsEnabled(for bucket: String, in region: Region) throws -> Bool {

--- a/Sources/hostmgr/helpers/S3.swift
+++ b/Sources/hostmgr/helpers/S3.swift
@@ -140,7 +140,12 @@ struct S3Manager {
 
         logger.log(level: .info, "Using Accelerated S3 Download")
 
-        return S3(client: aws, region: region, endpoint: "https://\(bucket).s3-accelerate.amazonaws.com", timeout: timeout)
+        return S3(
+            client: aws,
+            region: region,
+            endpoint: "https://\(bucket).s3-accelerate.amazonaws.com",
+            timeout: timeout
+        )
     }
 
     private func bucketTransferAccelerationIsEnabled(for bucket: String, in region: Region) throws -> Bool {

--- a/Sources/hostmgr/main.swift
+++ b/Sources/hostmgr/main.swift
@@ -5,7 +5,7 @@ import libhostmgr
 
 struct Hostmgr: ParsableCommand {
 
-    private var appVersion = "0.14.0"
+    private var appVersion = "0.14.1"
 
     static var configuration = CommandConfiguration(
         abstract: "A utility for managing VM hosts",


### PR DESCRIPTION
When running `hostmgr sync vm_images --force`, I constantly got errors like this:
```
2022-08-30T07:14:29+0000 trace com.automattic.hostmgr : ahc-connection-id=4 ahc-el=NIOTransportServices.NIOTSEventLoop ahc-request-id=4 aws-operation=GetObject aws-request-id=4 aws-service=s3 Request was cancelled
2022-08-30T07:14:29+0000 debug com.automattic.hostmgr : aws-error-message=HTTPClientError.deadlineExceeded aws-operation=GetObject aws-request-id=4 aws-service=s3 AWSClient errorError: HTTPClientError.deadlineExceeded
```

After a bit investigation, I found the soto-core library uses a [20 seconds timeout](https://github.com/soto-project/soto-core/blob/2a06f10160ba711921db4a2882280587b1479327/Sources/SotoCore/AWSServiceConfig.swift#L107) by default, which isn't enough to download an image from S3. In this PR I added a timeout value of 30 minutes.