### PR TITLE
Increase S3 client timeout to 2 hours

### DIFF
--- a/Sources/hostmgr/helpers/Logging.swift
+++ b/Sources/hostmgr/helpers/Logging.swift
@@ -1,9 +1,11 @@
+import Foundation
 import Logging
 
 var logger = Logger(label: "com.automattic.hostmgr")
 
 func initializeLoggingSystem() {
-    logger.logLevel = .trace
+    let logLevelFromEnv = ProcessInfo.processInfo.environment["LOG_LEVEL"].flatMap { Logger.Level(rawValue: $0) }
+    logger.logLevel = logLevelFromEnv ?? .info
     LoggingSystem.bootstrap { label in
         MultiplexLogHandler([
             StreamLogHandler.standardError(label: label)

--- a/Sources/hostmgr/helpers/S3.swift
+++ b/Sources/hostmgr/helpers/S3.swift
@@ -125,7 +125,7 @@ struct S3Manager {
         for bucket: String,
         in region: Region
     ) throws -> S3 {
-        let timeout = TimeAmount.minutes(30)
+        let timeout = TimeAmount.hours(2)
         let s3Client = S3(client: aws, region: region, timeout: timeout)
 
         guard Configuration.shared.allowAWSAcceleratedTransfer else {

--- a/Sources/hostmgr/main.swift
+++ b/Sources/hostmgr/main.swift
@@ -5,10 +5,11 @@ import libhostmgr
 
 struct Hostmgr: ParsableCommand {
 
-    private var appVersion = "0.14.1"
+    private static var appVersion = "0.14.2"
 
     static var configuration = CommandConfiguration(
         abstract: "A utility for managing VM hosts",
+        version: appVersion,
         subcommands: [
             VMCommand.self,
             SyncCommand.self,
@@ -18,25 +19,6 @@ struct Hostmgr: ParsableCommand {
             BenchmarkCommand.self,
             ConfigCommand.self
         ])
-
-    @Flag(help: "Print the version and exit")
-    var version: Bool = false
-
-    func run() throws {
-        guard version == false else {
-            print(appVersion)
-            return
-        }
-
-        logger.debug("Starting Up")
-
-        guard Configuration.isValid else {
-            print("Invalid configuration – exiting")
-            throw ExitCode(1)
-        }
-
-        throw CleanExit.helpRequest(self)
-    }
 }
 
 initializeLoggingSystem()


### PR DESCRIPTION
Currently, only 90% of the image was downloaded in 30 minutes, I'm not entirely sure why the downloading speed is so slow. In this PR, the timeout is increased to 2 hours—we can potentially reduce this if later find the cause of the slow downloading speed.

One suspect is the logging, there are _lots_ of trace logs from the soto libraries which might get in the way of downloading from S3 bucket. This PR changes the default logging level to info, but with an option to set it using environment variable, like `LOG_LEVEL=trace hostmgr sync vm_images`. I tried to add a `--verbose` global option, but I don't think swift-argument-parser supports specifying a global option at the top level command.

Another change is removing `Hostmgr.run` function, which does two things: print version or help message. They are replaced with the version flag came with `CommandConfiguration` and the help flag came with [the default `run` implementation](https://apple.github.io/swift-argument-parser/documentation/argumentparser/parsablecommand/run()-7p2fr). So, no CLI is changed, but we have less code.