### PR TITLE
Final tweak to the S3 client timeout value

### DIFF
--- a/Sources/hostmgr/helpers/S3.swift
+++ b/Sources/hostmgr/helpers/S3.swift
@@ -125,7 +125,9 @@ struct S3Manager {
         for bucket: String,
         in region: Region
     ) throws -> S3 {
-        let timeout = TimeAmount.hours(2)
+        // A VM image (about 25 GB) can be downloaded in about 25 mins. Setting this timeout to be slightly
+        // longer gives us some tolerance for slower downloading speed.
+        let timeout = TimeAmount.minutes(40)
         let s3Client = S3(client: aws, region: region, timeout: timeout)
 
         guard Configuration.shared.allowAWSAcceleratedTransfer else {


### PR DESCRIPTION
Having seen the real downloading speed now, this PR updates the timeout value to a close to reality value (40 minutes), rather than arbitrary large.