### PR TITLE
Set S3 download timeout based on the file size

### DIFF
--- a/Sources/hostmgr/helpers/S3.swift
+++ b/Sources/hostmgr/helpers/S3.swift
@@ -89,7 +89,8 @@ struct S3Manager {
             .value
         )
         let estimatedDownloadSpeedInMBPS: Int64 = 10
-        let timeout = totalMB / estimatedDownloadSpeedInMBPS
+        let minimalTimeout: Int64 = 60
+        let timeout = max(totalMB / estimatedDownloadSpeedInMBPS, minimalTimeout)
         logger.info("Download timeout: \(timeout / 60) minutes")
 
         let s3Client = try getS3Client(from: client, for: bucket, in: region).with(timeout: .seconds(timeout))

--- a/Sources/hostmgr/helpers/S3.swift
+++ b/Sources/hostmgr/helpers/S3.swift
@@ -80,7 +80,14 @@ struct S3Manager {
         let totalBytes = try getFileSize(region: region, bucket: bucket, key: key)
 
         // Estimate the time to download the file under 10 MB/s download speed
-        let totalMB = Int64(Measurement<UnitInformationStorage>(value: Double(totalBytes), unit: .bytes).converted(to: .megabytes).value)
+        let totalMB = Int64(
+            Measurement<UnitInformationStorage>(
+                value: Double(totalBytes),
+                unit: .bytes
+            )
+            .converted(to: .megabytes)
+            .value
+        )
         let timeout = totalMB / 10
         logger.info("Download timeout: \(timeout / 60) minutes")
 
@@ -131,7 +138,8 @@ struct S3Manager {
         in region: Region
     ) throws -> S3 {
         let options: AWSServiceConfig.Options
-        if try Configuration.shared.allowAWSAcceleratedTransfer && bucketTransferAccelerationIsEnabled(for: bucket, in: region) {
+        if try Configuration.shared.allowAWSAcceleratedTransfer
+            && bucketTransferAccelerationIsEnabled(for: bucket, in: region) {
             logger.log(level: .info, "Using Accelerated S3 Download")
             options = .s3UseTransferAcceleratedEndpoint
         } else {

--- a/Sources/hostmgr/helpers/S3.swift
+++ b/Sources/hostmgr/helpers/S3.swift
@@ -88,7 +88,8 @@ struct S3Manager {
             .converted(to: .megabytes)
             .value
         )
-        let timeout = totalMB / 10
+        let estimatedDownloadSpeedInMBPS: Int64 = 10
+        let timeout = totalMB / estimatedDownloadSpeedInMBPS
         logger.info("Download timeout: \(timeout / 60) minutes")
 
         let s3Client = try getS3Client(from: client, for: bucket, in: region).with(timeout: .seconds(timeout))


### PR DESCRIPTION
Since the VM image size varies, there are 25 GB ones, and there are close to 40 GB ones, using one single timeout value may cause failure when downloading larger VM images, unless we use an arbitrary large timeout value. This PR sets the timeout based on the file size, calculated with an expected downloading speed of 10 MB/s.

I found out there is a `.s3UseTransferAcceleratedEndpoint` option in the soto library, so I made a small change while I'm changing this code.

(Hopefully this is the last PR to tweak the timeout value 😂)