### PR TITLE
Update Swift Argument Parser

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser",
       "state" : {
-        "revision" : "6b2aa2748a7881eebb9f84fb10c01293e15b52ca",
-        "version" : "0.5.0"
+        "revision" : "9f39744e025c7d377987f30b03770805dcb0bcd1",
+        "version" : "1.1.4"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,178 +1,176 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "async-http-client",
-        "repositoryURL": "https://github.com/swift-server/async-http-client.git",
-        "state": {
-          "branch": null,
-          "revision": "794dc9d42720af97cedd395e8cd2add9173ffd9a",
-          "version": "1.11.1"
-        }
-      },
-      {
-        "package": "DotEnv",
-        "repositoryURL": "https://github.com/swiftpackages/DotEnv.git",
-        "state": {
-          "branch": null,
-          "revision": "1f15bb9de727d694af1d003a1a5d7a553752850f",
-          "version": "3.0.0"
-        }
-      },
-      {
-        "package": "jmespath.swift",
-        "repositoryURL": "https://github.com/adam-fowler/jmespath.swift.git",
-        "state": {
-          "branch": null,
-          "revision": "4513d319c4aaa6c3b2ac18e1e6566a803515ad91",
-          "version": "1.0.2"
-        }
-      },
-      {
-        "package": "kcpassword",
-        "repositoryURL": "https://github.com/jkmassel/kcpassword-swift.git",
-        "state": {
-          "branch": null,
-          "revision": "7bd487eb83285b54ff69c322f789c1b998fa7aff",
-          "version": "1.0.0"
-        }
-      },
-      {
-        "package": "prlctl",
-        "repositoryURL": "https://github.com/jkmassel/prlctl.git",
-        "state": {
-          "branch": null,
-          "revision": "3ac78a46de87182b2ed6bb7aab5d1ff017fa402b",
-          "version": "1.17.0"
-        }
-      },
-      {
-        "package": "ShellOut",
-        "repositoryURL": "https://github.com/JohnSundell/ShellOut",
-        "state": {
-          "branch": null,
-          "revision": "e1577acf2b6e90086d01a6d5e2b8efdaae033568",
-          "version": "2.3.0"
-        }
-      },
-      {
-        "package": "soto",
-        "repositoryURL": "https://github.com/soto-project/soto.git",
-        "state": {
-          "branch": null,
-          "revision": "9c938aadbbb33d6ed54d04dd6ba494f7f12e0905",
-          "version": "6.0.0"
-        }
-      },
-      {
-        "package": "soto-core",
-        "repositoryURL": "https://github.com/soto-project/soto-core.git",
-        "state": {
-          "branch": null,
-          "revision": "8e63c0f80db61f01c346f5109863bc2be29093e7",
-          "version": "6.0.0"
-        }
-      },
-      {
-        "package": "swift-argument-parser",
-        "repositoryURL": "https://github.com/apple/swift-argument-parser",
-        "state": {
-          "branch": null,
-          "revision": "6b2aa2748a7881eebb9f84fb10c01293e15b52ca",
-          "version": "0.5.0"
-        }
-      },
-      {
-        "package": "swift-log",
-        "repositoryURL": "https://github.com/apple/swift-log.git",
-        "state": {
-          "branch": null,
-          "revision": "5d66f7ba25daf4f94100e7022febf3c75e37a6c7",
-          "version": "1.4.2"
-        }
-      },
-      {
-        "package": "swift-metrics",
-        "repositoryURL": "https://github.com/apple/swift-metrics.git",
-        "state": {
-          "branch": null,
-          "revision": "3edd2f57afc4e68e23c3e4956bc8b65ca6b5b2ff",
-          "version": "2.2.0"
-        }
-      },
-      {
-        "package": "swift-nio",
-        "repositoryURL": "https://github.com/apple/swift-nio.git",
-        "state": {
-          "branch": null,
-          "revision": "124119f0bb12384cef35aa041d7c3a686108722d",
-          "version": "2.40.0"
-        }
-      },
-      {
-        "package": "swift-nio-extras",
-        "repositoryURL": "https://github.com/apple/swift-nio-extras.git",
-        "state": {
-          "branch": null,
-          "revision": "f73ca5ee9c6806800243f1ac415fcf82de9a4c91",
-          "version": "1.10.2"
-        }
-      },
-      {
-        "package": "swift-nio-http2",
-        "repositoryURL": "https://github.com/apple/swift-nio-http2.git",
-        "state": {
-          "branch": null,
-          "revision": "108ac15087ea9b79abb6f6742699cf31de0e8772",
-          "version": "1.22.0"
-        }
-      },
-      {
-        "package": "swift-nio-ssl",
-        "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
-        "state": {
-          "branch": null,
-          "revision": "5e68c1ded15619bb281b273fa8c2d8fd7f7b2b7d",
-          "version": "2.16.1"
-        }
-      },
-      {
-        "package": "swift-nio-transport-services",
-        "repositoryURL": "https://github.com/apple/swift-nio-transport-services.git",
-        "state": {
-          "branch": null,
-          "revision": "2cb54f91ddafc90832c5fa247faf5798d0a7c204",
-          "version": "1.13.0"
-        }
-      },
-      {
-        "package": "swift-system",
-        "repositoryURL": "https://github.com/apple/swift-system.git",
-        "state": {
-          "branch": null,
-          "revision": "836bc4557b74fe6d2660218d56e3ce96aff76574",
-          "version": "1.1.1"
-        }
-      },
-      {
-        "package": "swift-tools-support-core",
-        "repositoryURL": "https://github.com/apple/swift-tools-support-core",
-        "state": {
-          "branch": null,
-          "revision": "b7667f3e266af621e5cc9c77e74cacd8e8c00cb4",
-          "version": "0.2.5"
-        }
-      },
-      {
-        "package": "swift-tqdm",
-        "repositoryURL": "https://github.com/ebraraktas/swift-tqdm.git",
-        "state": {
-          "branch": null,
-          "revision": "71f0a47e1c1149cc486be2e436d7369e90ca4449",
-          "version": "0.1.2"
-        }
+  "pins" : [
+    {
+      "identity" : "async-http-client",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/async-http-client.git",
+      "state" : {
+        "revision" : "794dc9d42720af97cedd395e8cd2add9173ffd9a",
+        "version" : "1.11.1"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "dotenv",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftpackages/DotEnv.git",
+      "state" : {
+        "revision" : "1f15bb9de727d694af1d003a1a5d7a553752850f",
+        "version" : "3.0.0"
+      }
+    },
+    {
+      "identity" : "jmespath.swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/adam-fowler/jmespath.swift.git",
+      "state" : {
+        "revision" : "4513d319c4aaa6c3b2ac18e1e6566a803515ad91",
+        "version" : "1.0.2"
+      }
+    },
+    {
+      "identity" : "kcpassword-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jkmassel/kcpassword-swift.git",
+      "state" : {
+        "revision" : "7bd487eb83285b54ff69c322f789c1b998fa7aff",
+        "version" : "1.0.0"
+      }
+    },
+    {
+      "identity" : "prlctl",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jkmassel/prlctl.git",
+      "state" : {
+        "revision" : "3ac78a46de87182b2ed6bb7aab5d1ff017fa402b",
+        "version" : "1.17.0"
+      }
+    },
+    {
+      "identity" : "shellout",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/JohnSundell/ShellOut",
+      "state" : {
+        "revision" : "e1577acf2b6e90086d01a6d5e2b8efdaae033568",
+        "version" : "2.3.0"
+      }
+    },
+    {
+      "identity" : "soto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/soto-project/soto.git",
+      "state" : {
+        "revision" : "9c938aadbbb33d6ed54d04dd6ba494f7f12e0905",
+        "version" : "6.0.0"
+      }
+    },
+    {
+      "identity" : "soto-core",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/soto-project/soto-core.git",
+      "state" : {
+        "revision" : "8e63c0f80db61f01c346f5109863bc2be29093e7",
+        "version" : "6.0.0"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "6b2aa2748a7881eebb9f84fb10c01293e15b52ca",
+        "version" : "0.5.0"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "5d66f7ba25daf4f94100e7022febf3c75e37a6c7",
+        "version" : "1.4.2"
+      }
+    },
+    {
+      "identity" : "swift-metrics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-metrics.git",
+      "state" : {
+        "revision" : "3edd2f57afc4e68e23c3e4956bc8b65ca6b5b2ff",
+        "version" : "2.2.0"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "124119f0bb12384cef35aa041d7c3a686108722d",
+        "version" : "2.40.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-extras.git",
+      "state" : {
+        "revision" : "f73ca5ee9c6806800243f1ac415fcf82de9a4c91",
+        "version" : "1.10.2"
+      }
+    },
+    {
+      "identity" : "swift-nio-http2",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-http2.git",
+      "state" : {
+        "revision" : "108ac15087ea9b79abb6f6742699cf31de0e8772",
+        "version" : "1.22.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-ssl",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-ssl.git",
+      "state" : {
+        "revision" : "5e68c1ded15619bb281b273fa8c2d8fd7f7b2b7d",
+        "version" : "2.16.1"
+      }
+    },
+    {
+      "identity" : "swift-nio-transport-services",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-transport-services.git",
+      "state" : {
+        "revision" : "2cb54f91ddafc90832c5fa247faf5798d0a7c204",
+        "version" : "1.13.0"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "836bc4557b74fe6d2660218d56e3ce96aff76574",
+        "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-tools-support-core",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-tools-support-core",
+      "state" : {
+        "revision" : "b7667f3e266af621e5cc9c77e74cacd8e8c00cb4",
+        "version" : "0.2.5"
+      }
+    },
+    {
+      "identity" : "swift-tqdm",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ebraraktas/swift-tqdm.git",
+      "state" : {
+        "revision" : "71f0a47e1c1149cc486be2e436d7369e90ca4449",
+        "version" : "0.1.2"
+      }
+    }
+  ],
+  "version" : 2
 }

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/apple/swift-argument-parser", from: "0.4.0"),
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.1.4"),
         .package(url: "https://github.com/soto-project/soto.git", from: "6.0.0"),
         .package(url: "https://github.com/jkmassel/prlctl.git", from: "1.17.0"),
         .package(url: "https://github.com/ebraraktas/swift-tqdm.git", from: "0.1.2"),

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.6
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -15,7 +15,7 @@ let package = Package(
         .package(url: "https://github.com/jkmassel/prlctl.git", from: "1.17.0"),
         .package(url: "https://github.com/ebraraktas/swift-tqdm.git", from: "0.1.2"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
-        .package(name: "kcpassword", url: "https://github.com/jkmassel/kcpassword-swift.git", from: "1.0.0"),
+        .package(url: "https://github.com/jkmassel/kcpassword-swift.git", from: "1.0.0"),
         .package(url: "https://github.com/swiftpackages/DotEnv.git", from: "3.0.0"),
         .package(url: "https://github.com/apple/swift-tools-support-core", from: "0.2.5")
 
@@ -23,7 +23,7 @@ let package = Package(
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
-        .target(
+        .executableTarget(
             name: "hostmgr",
             dependencies: [
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
@@ -31,7 +31,7 @@ let package = Package(
                 .product(name: "prlctl", package: "prlctl"),
                 .product(name: "Tqdm", package: "swift-tqdm"),
                 .product(name: "Logging", package: "swift-log"),
-                .product(name: "kcpassword", package: "kcpassword"),
+                .product(name: "kcpassword", package: "kcpassword-swift"),
                 .target(name: "libhostmgr")
             ]
         ),

--- a/Sources/hostmgr/HostMgrCommand.swift
+++ b/Sources/hostmgr/HostMgrCommand.swift
@@ -4,7 +4,7 @@ import Logging
 import libhostmgr
 
 @main
-struct Hostmgr: ParsableCommand {
+struct Hostmgr: AsyncParsableCommand {
 
     private static var appVersion = "0.14.2"
 
@@ -22,7 +22,7 @@ struct Hostmgr: ParsableCommand {
         ]
     )
 
-    mutating func run() throws {
+    mutating func run() async throws {
         Logger.initializeLoggingSystem()
 
         logger.trace("Starting Up")

--- a/Sources/hostmgr/HostMgrCommand.swift
+++ b/Sources/hostmgr/HostMgrCommand.swift
@@ -3,6 +3,7 @@ import SotoS3
 import Logging
 import libhostmgr
 
+@main
 struct Hostmgr: ParsableCommand {
 
     private static var appVersion = "0.14.2"
@@ -18,11 +19,22 @@ struct Hostmgr: ParsableCommand {
             SetCommand.self,
             BenchmarkCommand.self,
             ConfigCommand.self
-        ])
-}
+        ]
+    )
 
-Logger.initializeLoggingSystem()
-Hostmgr.main()
+    mutating func run() throws {
+        Logger.initializeLoggingSystem()
+
+        logger.trace("Starting Up")
+
+        guard Configuration.isValid else {
+            print("Invalid configuration – exiting")
+            throw ExitCode(1)
+        }
+
+        throw CleanExit.helpRequest(self)
+    }
+}
 
 struct SetCommand: ParsableCommand {
     static let configuration = CommandConfiguration(

--- a/Sources/hostmgr/helpers/Logging.swift
+++ b/Sources/hostmgr/helpers/Logging.swift
@@ -1,14 +1,33 @@
 import Foundation
 import Logging
 
-var logger = Logger(label: "com.automattic.hostmgr")
+/// A hack to allow global logging
+struct logger {
+    static func debug(_ message:  @autoclosure () -> Logger.Message) {
+        Logger.shared.debug(message())
+    }
 
-func initializeLoggingSystem() {
-    let logLevelFromEnv = ProcessInfo.processInfo.environment["LOG_LEVEL"].flatMap { Logger.Level(rawValue: $0) }
-    logger.logLevel = logLevelFromEnv ?? .info
-    LoggingSystem.bootstrap { label in
-        MultiplexLogHandler([
-            StreamLogHandler.standardError(label: label)
-        ])
+    static func trace(_ message:  @autoclosure () -> Logger.Message) {
+        Logger.shared.trace(message())
+    }
+
+    static func info(_ message:  @autoclosure () -> Logger.Message) {
+        Logger.shared.info(message())
+    }
+}
+
+extension Logger {
+    static var shared = Logger(label: "com.automattic.hostmgr")
+
+    static func initializeLoggingSystem() {
+        #if DEBUG
+        Logger.shared.logLevel = .trace
+        #endif
+
+        LoggingSystem.bootstrap { label in
+            MultiplexLogHandler([
+                StreamLogHandler.standardError(label: label)
+            ])
+        }
     }
 }

--- a/Sources/hostmgr/helpers/Logging.swift
+++ b/Sources/hostmgr/helpers/Logging.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Logging
 
+// swiftlint:disable type_name
 /// A hack to allow global logging
 struct logger {
     static func debug(_ message:  @autoclosure () -> Logger.Message) {

--- a/Sources/hostmgr/helpers/Logging.swift
+++ b/Sources/hostmgr/helpers/Logging.swift
@@ -16,6 +16,7 @@ struct logger {
         Logger.shared.info(message())
     }
 }
+// swiftlint:enable type_name
 
 extension Logger {
     static var shared = Logger(label: "com.automattic.hostmgr")

--- a/Sources/hostmgr/helpers/Logging.swift
+++ b/Sources/hostmgr/helpers/Logging.swift
@@ -21,8 +21,12 @@ extension Logger {
     static var shared = Logger(label: "com.automattic.hostmgr")
 
     static func initializeLoggingSystem() {
+
         #if DEBUG
         Logger.shared.logLevel = .trace
+        #else
+        let logLevelFromEnv = ProcessInfo.processInfo.environment["LOG_LEVEL"].flatMap { Logger.Level(rawValue: $0) }
+        Logger.shared.logLevel = logLevelFromEnv ?? .info
         #endif
 
         LoggingSystem.bootstrap { label in

--- a/Sources/hostmgr/helpers/S3.swift
+++ b/Sources/hostmgr/helpers/S3.swift
@@ -96,7 +96,7 @@ struct S3Manager {
         let s3Client = try getS3Client(from: client, for: bucket, in: region).with(timeout: .seconds(timeout))
         let objectRequest = S3.GetObjectRequest(bucket: bucket, key: key)
 
-        _ = try s3Client.getObjectStreaming(objectRequest, logger: logger) { buffer, loop in
+        _ = try s3Client.getObjectStreaming(objectRequest, logger: Logger.shared) { buffer, loop in
             let availableBytes = buffer.readableBytes
             downloadedBytes += availableBytes
             if let bytes = buffer.getData(at: buffer.readerIndex, length: availableBytes) {
@@ -142,10 +142,10 @@ struct S3Manager {
         let options: AWSServiceConfig.Options
         if try Configuration.shared.allowAWSAcceleratedTransfer
             && bucketTransferAccelerationIsEnabled(for: bucket, in: region) {
-            logger.log(level: .info, "Using Accelerated S3 Download")
+            logger.info("Using Accelerated S3 Download")
             options = .s3UseTransferAcceleratedEndpoint
         } else {
-            logger.log(level: .info, "Using Standard S3 Download")
+            logger.info("Using Standard S3 Download")
             options = []
         }
 
@@ -165,7 +165,7 @@ struct S3Manager {
 
         let bucketInfoRequest = S3.GetBucketAccelerateConfigurationRequest(bucket: bucket)
         return try S3(client: client, region: region)
-            .getBucketAccelerateConfiguration(bucketInfoRequest, logger: logger)
+            .getBucketAccelerateConfiguration(bucketInfoRequest, logger: Logger.shared)
             .wait()
             .status == .enabled
     }

--- a/Sources/hostmgr/main.swift
+++ b/Sources/hostmgr/main.swift
@@ -21,7 +21,7 @@ struct Hostmgr: ParsableCommand {
         ])
 }
 
-initializeLoggingSystem()
+Logger.initializeLoggingSystem()
 Hostmgr.main()
 
 struct SetCommand: ParsableCommand {


### PR DESCRIPTION
Update the Swift Argument Parser Dependency – this allows for `async` commands, paving the way for async/await across the project.