### PR TITLE
Add Console Output Helper

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -179,15 +179,6 @@
         "revision" : "b7667f3e266af621e5cc9c77e74cacd8e8c00cb4",
         "version" : "0.2.5"
       }
-    },
-    {
-      "identity" : "swift-tqdm",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ebraraktas/swift-tqdm.git",
-      "state" : {
-        "revision" : "71f0a47e1c1149cc486be2e436d7369e90ca4449",
-        "version" : "0.1.2"
-      }
     }
   ],
   "version" : 2

--- a/Package.resolved
+++ b/Package.resolved
@@ -19,6 +19,15 @@
       }
     },
     {
+      "identity" : "console-kit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/vapor/console-kit",
+      "state" : {
+        "revision" : "a7e67a1719933318b5ab7eaaed355cde020465b1",
+        "version" : "4.5.0"
+      }
+    },
+    {
       "identity" : "dotenv",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftpackages/DotEnv.git",

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,6 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.1.4"),
         .package(url: "https://github.com/soto-project/soto.git", from: "6.0.0"),
         .package(url: "https://github.com/jkmassel/prlctl.git", from: "1.17.0"),
-        .package(url: "https://github.com/ebraraktas/swift-tqdm.git", from: "0.1.2"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/jkmassel/kcpassword-swift.git", from: "1.0.0"),
         .package(url: "https://github.com/swiftpackages/DotEnv.git", from: "3.0.0"),
@@ -29,7 +28,6 @@ let package = Package(
             dependencies: [
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 .product(name: "prlctl", package: "prlctl"),
-                .product(name: "Tqdm", package: "swift-tqdm"),
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "kcpassword", package: "kcpassword-swift"),
                 .target(name: "libhostmgr"),

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,8 @@ let package = Package(
         .package(url: "https://github.com/jkmassel/kcpassword-swift.git", from: "1.0.0"),
         .package(url: "https://github.com/swiftpackages/DotEnv.git", from: "3.0.0"),
         .package(url: "https://github.com/apple/swift-tools-support-core", from: "0.2.5"),
-        .package(url: "https://github.com/Alamofire/Alamofire.git", .upToNextMajor(from: "5.6.1"))
+        .package(url: "https://github.com/Alamofire/Alamofire.git", .upToNextMajor(from: "5.6.1")),
+        .package(url: "https://github.com/vapor/console-kit.git", .upToNextMajor(from: "4.5.0")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -41,6 +42,7 @@ let package = Package(
                 .product(name: "SotoS3", package: "soto"),
                 .product(name: "TSCBasic", package: "swift-tools-support-core"),
                 .product(name: "Alamofire", package: "Alamofire"),
+                .product(name: "ConsoleKit", package: "console-kit"),
             ]
         ),
         .testTarget(

--- a/Sources/hostmgr/commands/benchmark/NetworkBenchmark.swift
+++ b/Sources/hostmgr/commands/benchmark/NetworkBenchmark.swift
@@ -27,32 +27,16 @@ struct NetworkBenchmark: AsyncParsableCommand {
             region: Configuration.shared.vmImagesRegion
         )
 
+        let progressBar = Console.startFileDownload(file.imageObject)
+
         try await manager.download(
             object: file.imageObject,
             to: FileManager.default.temporaryFilePath(),
-            progressCallback: self.updateProgress
+            progressCallback: progressBar.update
         )
     }
 
     private func imageSizeSort(_ lhs: RemoteVMImage, _ rhs: RemoteVMImage) -> Bool {
         lhs.imageObject.size < rhs.imageObject.size
-    }
-
-    private func updateProgress(_ progress: FileTransferProgress) {
-        Self.limiter.perform {
-            let downloadedSize = ByteCountFormatter.string(fromByteCount: Int64(progress.current), countStyle: .file)
-            let totalSize = ByteCountFormatter.string(fromByteCount: Int64(progress.total), countStyle: .file)
-
-            let secondsElapsed = Date().timeIntervalSince(startDate)
-            let perSecond = Double(progress.current) / Double(secondsElapsed)
-
-            // Don't continue unless the rate can be represented by `Int64`
-            guard perSecond.isNormal else {
-                return
-            }
-
-            let rate = ByteCountFormatter.string(fromByteCount: Int64(perSecond), countStyle: .file)
-            logger.info("Downloaded \(downloadedSize) of \(totalSize) [Rate: \(rate) per second]")
-        }
     }
 }

--- a/Sources/hostmgr/commands/sync/SyncVMImagesCommand.swift
+++ b/Sources/hostmgr/commands/sync/SyncVMImagesCommand.swift
@@ -60,10 +60,12 @@ struct SyncVMImagesCommand: AsyncParsableCommand, FollowsCommandPolicies {
 
         let limiter = Limiter(policy: .throttle, operationsPerSecond: 1)
 
+        let progressBar = Console.startImageDownload(image)
         try await RemoteVMRepository().download(image: image, to: destination) { progress in
+            progressBar.update(progress)
+
             limiter.perform {
                 try? recordHeartbeat()
-                logger.info("\(progress.decimalPercent)% complete")
             }
         }
 

--- a/Sources/hostmgr/commands/vm/image/remote/VMRemoteImageDownload.swift
+++ b/Sources/hostmgr/commands/vm/image/remote/VMRemoteImageDownload.swift
@@ -48,17 +48,10 @@ struct VMRemoteImageDownload: AsyncParsableCommand {
         let sleepManager = SystemSleepManager(reason: "Downloading \(remoteImage.fileName)")
         sleepManager.disable()
 
-        let progressBar = Tqdm(
-            description: "Downloading \(remoteImage.fileName)",
-            total: Int(remoteImage.imageObject.size),
-            unit: " bytes",
-            unitScale: true
-        )
+        let progressBar = Console.startImageDownload(remoteImage)
 
         try await remote.download(image: remoteImage, to: destination) {
-            progressBar.update(n: $0.percent)
+            progressBar.update($0)
         }
-
-        progressBar.close()
     }
 }

--- a/Sources/hostmgr/commands/vm/image/remote/VMRemoteImageDownload.swift
+++ b/Sources/hostmgr/commands/vm/image/remote/VMRemoteImageDownload.swift
@@ -1,6 +1,5 @@
 import Foundation
 import ArgumentParser
-import Tqdm
 import libhostmgr
 
 struct VMRemoteImageDownload: AsyncParsableCommand {

--- a/Sources/libhostmgr/CLI/Console.swift
+++ b/Sources/libhostmgr/CLI/Console.swift
@@ -1,0 +1,199 @@
+import Foundation
+import ConsoleKit
+
+public struct Console {
+
+    let terminal = Terminal()
+
+    @discardableResult public func heading(_ message: String, underline: String = "=") -> Self {
+        self.terminal.output(message, style: .plain)
+        self.terminal.output(String.init(repeating: underline, count: message.count), style: .plain)
+        return self
+    }
+
+    @discardableResult public func success(_ message: String) -> Self {
+        self.terminal.success(message)
+        return self
+    }
+
+    @discardableResult public func error(_ message: String) -> Self {
+        self.terminal.error(message)
+        return self
+    }
+
+    @discardableResult public func warn(_ message: String) -> Self {
+        self.terminal.warning(message)
+        return self
+    }
+
+    @discardableResult public func info(_ message: String) -> Self {
+        self.terminal.info(message)
+        return self
+    }
+
+    @discardableResult public func log(_ message: String) -> Self {
+        self.terminal.print(message)
+        return self
+    }
+
+    @discardableResult func message(_ message: String, style: ConsoleStyle) -> Self {
+        self.terminal.output(message, style: style)
+        return self
+    }
+
+    @discardableResult public func printList(_ list: [String], title: String) -> Self {
+        self.terminal.print(title)
+
+        guard !list.isEmpty else {
+            self.terminal.print("  [Empty]")
+            return self
+        }
+
+        for item in list {
+            self.terminal.print("  " + item)
+        }
+
+        return self
+    }
+
+    @discardableResult public func printTable(
+        data: Table,
+        columnTitles: [String] = [],
+        columnSeparator: String = "  "
+    ) -> Self {
+
+        if data.isEmpty {
+            self.terminal.print("[Empty]")
+            return self
+        }
+
+        // Prepend the Column Titles, if present
+        let table = columnTitles.isEmpty ? data : [columnTitles] + data
+
+        let columnCount = columnCounts(for: table)
+
+        for row in table {
+            let string = zip(row, columnCount).map(self.padString).joined(separator: columnSeparator)
+            self.terminal.print(string)
+        }
+
+        return self
+    }
+}
+
+public struct ProgressBar {
+
+    private let terminal = Terminal()
+    private let startDate = Date()
+
+    init(title: String) {
+        terminal.info(title)
+        terminal.print() // Deliberately empty string
+    }
+
+    public static func start(title: String) -> Self {
+        return ProgressBar(title: title)
+    }
+
+    public func update(_ progress: FileTransferProgress) {
+        terminal.clear(lines: 1)
+
+        let elapsedTime = Date().timeIntervalSince(startDate)
+
+        let rate = progress.dataRate(timeIntervalSinceStart: elapsedTime)
+        let remaining = progress.estimatedTimeRemaining(timeIntervalSinceStart: elapsedTime)
+
+        terminal.print("\(progress.formattedPercentage)% [\(rate)/s, \(Format.time(remaining))]")
+    }
+}
+
+// MARK: Static Helpers
+extension Console {
+    public static func startProgress(_ string: String) -> ProgressBar {
+        ProgressBar(title: string)
+    }
+
+    public static func startImageDownload(_ image: RemoteVMImage) -> ProgressBar {
+        let size = Format.fileBytes(image.imageObject.size)
+        return ProgressBar(title: "Downloading \(image.fileName) (\(size))")
+    }
+
+    public static func startFileDownload(_ file: S3Object) -> ProgressBar {
+        let size = Format.fileBytes(file.size)
+        return ProgressBar(title: "Downloading \(file.key) (\(size))")
+    }
+}
+
+// MARK: Static Initializers
+extension Console {
+    @discardableResult public static func heading(_ message: String) -> Self {
+        return Console().heading(message)
+    }
+
+    @discardableResult public static func success(_ message: String) -> Self {
+        return Console().success(message)
+    }
+
+    @discardableResult public static func error(_ message: String) -> Self {
+        return Console().error(message)
+    }
+
+    @discardableResult public static func warn(_ message: String) -> Self {
+        return Console().warn(message)
+    }
+
+    @discardableResult public static func info(_ message: String) -> Self {
+        return Console().info(message)
+    }
+
+    @discardableResult public static func log(_ message: String) -> Self {
+        return Console().log(message)
+    }
+
+    @discardableResult public static func printList(_ list: [String], title: String) -> Self {
+        return Console().printList(list, title: title)
+    }
+
+    @discardableResult public static func printTable(data: Table, columnTitles: [String] = []) -> Self {
+        return Console().printTable(data: data, columnTitles: columnTitles)
+    }
+
+    public static func crash(message: String, reason error: ExitCode) -> Never {
+        Console().error(message)
+        Foundation.exit(error.rawValue)
+    }
+
+    public static func exit(message: String = "", style: ConsoleStyle = .plain) -> Never {
+        Console().message(message, style: style)
+        Foundation.exit(0)
+    }
+}
+
+// MARK: Table Support
+extension Console {
+    public typealias Table = [[String]]
+
+    func columnCounts(for table: Table) -> [Int] {
+        transpose(matrix: table).map { $0.map(\.count).max() ?? 0 }
+    }
+
+    func transpose(matrix: Table) -> Table {
+        guard let numberOfColumns = matrix.first?.count else {
+            return matrix
+        }
+
+        var newTable = [[String]](repeating: [String](repeating: "", count: matrix.count), count: numberOfColumns)
+
+        for (rowIndex, row) in matrix.enumerated() {
+            for (colIndex, col) in row.enumerated() {
+                newTable[colIndex][rowIndex] = col
+            }
+        }
+
+        return newTable
+    }
+
+    func padString(_ string: String, toLength length: Int) -> String {
+        string.padding(toLength: length, withPad: " ", startingAt: 0)
+    }
+}

--- a/Sources/libhostmgr/CLI/Console.swift
+++ b/Sources/libhostmgr/CLI/Console.swift
@@ -171,7 +171,9 @@ extension Console {
 
 // MARK: Table Support
 extension Console {
-    public typealias Table = [[String]]
+
+    public typealias TableRow = [String]
+    public typealias Table = [TableRow]
 
     func columnCounts(for table: Table) -> [Int] {
         transpose(matrix: table).map { $0.map(\.count).max() ?? 0 }
@@ -182,7 +184,7 @@ extension Console {
             return matrix
         }
 
-        var newTable = [[String]](repeating: [String](repeating: "", count: matrix.count), count: numberOfColumns)
+        var newTable = Table(repeating: TableRow(repeating: "", count: matrix.count), count: numberOfColumns)
 
         for (rowIndex, row) in matrix.enumerated() {
             for (colIndex, col) in row.enumerated() {

--- a/Sources/libhostmgr/CLI/ExitCode.swift
+++ b/Sources/libhostmgr/CLI/ExitCode.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+public enum ExitCode: Int32, Error {
+    case fileNotFound
+    case unableToFindRemoteImage
+    case unableToImportVM
+    case invalidVMStatus
+    case notEnoughLocalDiskSpace
+    case parallelsVirtualMachineDoesNotExist
+    case parallelsVirtualMachineIsNotStopped
+    case parallelsVirtualMachineAlreadyExists
+}

--- a/Sources/libhostmgr/CLI/Format.swift
+++ b/Sources/libhostmgr/CLI/Format.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+public struct Format {
+
+    public static func fileBytes(_ count: Int) -> String {
+        fileBytes(Int64(count))
+    }
+
+    public static func fileBytes(_ count: Int64) -> String {
+        let formatter = ByteCountFormatter()
+        formatter.zeroPadsFractionDigits = true
+        formatter.countStyle = .file
+        return formatter.string(fromByteCount: count)
+    }
+
+    public static func memoryBytes(_ count: UInt64) -> String {
+        memoryBytes(Int64(count))
+    }
+
+    public static func memoryBytes(_ count: Int64) -> String {
+        let formatter = ByteCountFormatter()
+        formatter.zeroPadsFractionDigits = true
+        formatter.countStyle = .memory
+        return formatter.string(fromByteCount: count)
+    }
+
+    public static func time(_ interval: TimeInterval) -> String {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.formattingContext = .standalone
+        return formatter.localizedString(fromTimeInterval: interval)
+    }
+}

--- a/Sources/libhostmgr/S3Manager.swift
+++ b/Sources/libhostmgr/S3Manager.swift
@@ -135,6 +135,13 @@ public struct S3Manager: S3ManagerProtocol {
             try await awsClient.shutdown()
             throw error
         }
+
+        // We need to shutdown the client also when `block` run successfully.
+        //
+        // This duplication with the call above will disappear once Swift will
+        // give us a way to call `defer`.
+        try await awsClient.shutdown()
+
         return result
     }
 

--- a/Sources/libhostmgr/S3Manager.swift
+++ b/Sources/libhostmgr/S3Manager.swift
@@ -146,30 +146,65 @@ public struct S3Object {
 }
 
 public struct FileTransferProgress {
-    public let current: Int
-    public let total: Int
+    public typealias Percentage = Decimal
 
-    public let estimatedTimeRemaining: TimeInterval?
+    let current: Int
+    let total: Int
 
-    public init(current: Int, total: Int, estimatedTimeRemaining: TimeInterval?) {
+    public init(current: Int, total: Int) {
         self.current = current
         self.total = total
-        self.estimatedTimeRemaining = estimatedTimeRemaining
     }
 
-    public var percent: Int {
-        Int(decimalPercent)
+    public var percent: Percentage {
+        Decimal(Double(self.current) / Double(self.total) * 100.0)
     }
 
-    public var decimalPercent: Double {
-        Double(current) / Double(total) * 100
+    public var downloadedData: String {
+        ByteCountFormatter.string(fromByteCount: Int64(current), countStyle: .file)
+    }
+
+    public var totalData: String {
+        ByteCountFormatter.string(fromByteCount: Int64(total), countStyle: .file)
+    }
+
+    public func dataRate(timeIntervalSinceStart interval: TimeInterval) -> String {
+        let bytesPerSecond = Double(current) / interval
+
+        // Don't continue unless the rate can be represented by `Int64`
+        guard bytesPerSecond.isNormal else {
+            return ByteCountFormatter.string(fromByteCount: 0, countStyle: .file)
+        }
+
+        return ByteCountFormatter.string(fromByteCount: Int64(bytesPerSecond), countStyle: .file)
+    }
+
+    public func estimatedTimeRemaining(timeIntervalSinceStart interval: TimeInterval) -> TimeInterval {
+        let bytesPerSecond = Double(current) / interval
+
+        // Don't continue unless the rate makes some kind of sense
+        guard bytesPerSecond.isNormal else {
+            return .infinity
+        }
+
+        let totalNumberOfSeconds = Double(total) / bytesPerSecond
+
+        return totalNumberOfSeconds - interval
+    }
+
+    public var formattedPercentage: String {
+        let formatter = NumberFormatter()
+        formatter.alwaysShowsDecimalSeparator = true
+        formatter.roundingMode = .down
+        formatter.minimumFractionDigits = 2
+        formatter.maximumFractionDigits = 2
+        return formatter.string(from: percent as NSDecimalNumber)!
     }
 
     static func progressData(from progress: Progress) -> FileTransferProgress {
         return FileTransferProgress(
             current: Int(progress.completedUnitCount),
-            total: Int(progress.totalUnitCount),
-            estimatedTimeRemaining: progress.estimatedTimeRemaining
+            total: Int(progress.totalUnitCount)
         )
     }
 }

--- a/Tests/libhostmgrTests/CLI/ConsoleTests.swift
+++ b/Tests/libhostmgrTests/CLI/ConsoleTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+@testable import libhostmgr
+
+final class ConsoleTests: XCTestCase {
+
+    // MARK: Table Calculations
+    func testThatColumnCountWorks() throws {
+        let table = [["Jack", "Reacher"], ["James", "Bond"], ["Jason", "Bourne"]]
+        XCTAssertEqual([5, 7], Console().columnCounts(for: table))
+    }
+
+    func testThatTransposeWorks() throws {
+        let original = [
+            ["Jack", "Reacher"],
+            ["James", "Bond"],
+            ["Jason", "Bourne"]
+        ]
+        let transposed = [
+            ["Jack", "James", "Jason"],
+            ["Reacher", "Bond", "Bourne"]
+        ]
+        XCTAssertEqual(transposed, Console().transpose(matrix: original))
+    }
+}


### PR DESCRIPTION
Adds a console output helper that'll make it easier to properly print status messages, errors, and warnings. 

Subsequent PRs will use it further.

**To Test:**
- Ensure tests pass
- Run `swift run hostmgr vm image remote download xcode-14`, ensure it correctly displays progress
- Run `swift run hostmgr benchmark network`, ensure it correctly displays progress

 