### PR TITLE
Ensure we shutdown the S3 client even when operations fail

### DIFF
--- a/Sources/libhostmgr/S3Manager.swift
+++ b/Sources/libhostmgr/S3Manager.swift
@@ -135,6 +135,13 @@ public struct S3Manager: S3ManagerProtocol {
             try await awsClient.shutdown()
             throw error
         }
+
+        // We need to shutdown the client also when `block` run successfully.
+        //
+        // This duplication with the call above will disappear once Swift will
+        // give us a way to call `defer`.
+        try await awsClient.shutdown()
+
         return result
     }
 


### PR DESCRIPTION
I've been unsuccessfully trying to test #41, my attempts failing with:

```
➜ swift run hostmgr benchmark network
Building for debugging...
Build complete! (0.29s)
SotoCore/AWSClient.swift:110: Assertion failed: AWSClient not shut down before the deinit. Please call client.syncShutdown() when no longer needed.
[1]    65387 trace trap  swift run hostmgr benchmark network
```

I've been doing some digging and discovered that error was hiding the actual one thrown by the command. This PR addresses the issue.

My attempts are still failing, but now the error is more accurate:

```
➜ swift run hostmgr benchmark network
Building for debugging...
Build complete! (0.30s)
Error: No credential provider found
```