### PR TITLE
Forward `IMAGE_ID` from Buildkite environment

### DIFF
--- a/Sources/hostmgr/commands/generate/GenerateBuildkiteJobScript.swift
+++ b/Sources/hostmgr/commands/generate/GenerateBuildkiteJobScript.swift
@@ -16,6 +16,9 @@ struct GenerateBuildkiteJobScript: ParsableCommand {
         scriptBuilder.addDependency(atPath: "~/.circ")
         scriptBuilder.addEnvironmentVariable(named: "BUILDKITE", value: "true")
         scriptBuilder.copyEnvironmentVariables(prefixedBy: "BUILDKITE_")
+        // We only have one environment variable called IMAGE_ID, but there is
+        // no method to copy individual env vars.
+        scriptBuilder.copyEnvironmentVariables(prefixedBy: "IMAGE_ID")
         scriptBuilder.addCommand("buildkite-agent bootstrap")
 
         // Manually specify the build path to keep them nice and clean in the output


### PR DESCRIPTION
I wanted to [check if the agent had `IMAGE_ID =~ ^xcode` and run `brew install xcodes` if so in a pre-commit hook](https://buildkite.com/automattic/woocommerce-ios/builds/9006#01847ff9-24a9-47d7-ba20-7ed47a5ce159/243-245), but it turns out that env var is not available to the scripts.

---

I tried to add tests for this change but run into a limitation with the setup. 

I started by duplicating the test from `BuildkiteScriptBuilderTests` that verifies that all `BUILDKITE_*` values are copied and modified it to use `IMAGE_ID` from a new `.env` file:

https://github.com/Automattic/hostmgr/blob/40287d22e53a6c593d37a37b3479bd2459eab94e/Tests/libhostmgrTests/BuildkiteScriptBuilderTests.swift#L62-L69

I was surprised to see it passed. I then realized that test verifies the ability of the method to copy all env vars matching the given pattern from the given file. It makes no assertion on whether we do copy `BUILDKITE_` env vars at runtime. The component responsible for that behavior is [`GenerateBuildkiteJobScript` from the `hostmgr` executable target](https://github.com/Automattic/hostmgr/blob/40287d22e53a6c593d37a37b3479bd2459eab94e/Sources/hostmgr/commands/generate/GenerateBuildkiteJobScript.swift).

I don't know how to test an executable target. As a matter of fact, we do have a draft of test for `hostmgr` which does not run because not configured in `Package.swift`, [`SyncVMImagesCommandTests`](https://github.com/Automattic/hostmgr/blob/40287d22e53a6c593d37a37b3479bd2459eab94e/Tests/hostmgrTests/SyncVMImagesCommandTests.swift).

```
➜ swift test | grep SyncVMImagesCommandTests | wc -l
Compiling plugin GenerateManualPlugin...
Building for debugging...
Build complete! (0.30s)
0

# conversely, with a test that does run
➜ swift test | grep BuildkiteScriptBuilderTests | wc -l
Compiling plugin GenerateManualPlugin...
Building for debugging...
Build complete! (0.31s)
26
```

I have a "solution" in mind, which I'll propose in a dedicated issue. But for the time being, this change does the job of forwarding `IMAGE_ID`.