### PR TITLE
Consolidate Configuration

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,7 +4,7 @@ common_params:
   - &bash_cache automattic/bash-cache#v1.3.2: ~
   # Common environment values to use with the `env` key.
   env: &common_env
-    IMAGE_ID: xcode-13.4.1
+    IMAGE_ID: xcode-14.2
 
 # This is the default pipeline – it will build and test the app
 steps:

--- a/Sources/hostmgr/HostMgrCommand.swift
+++ b/Sources/hostmgr/HostMgrCommand.swift
@@ -52,7 +52,7 @@ struct InitCommand: ParsableCommand {
     )
 
     func run() throws {
-        if StateManager.configurationFileExists {
+        if ConfigurationRepository.configurationFileExists {
             if !confirm("A configuration file already exists – would you like to continue?") {
                 return
             }

--- a/Sources/hostmgr/commands/generate/GenerateGitMirrorManifestCommand.swift
+++ b/Sources/hostmgr/commands/generate/GenerateGitMirrorManifestCommand.swift
@@ -18,16 +18,16 @@ struct GenerateGitMirrorManifestCommand: ParsableCommand {
 struct GenerateGitMirrorManifestTask {
     func run() throws {
         let paths = FileManager.default
-            .subpaths(at: Configuration.shared.gitMirrorDirectory)
+            .subpaths(at: Paths.gitMirrorStorageDirectory)
 
         let manifest = generateTextManifest(fromPaths: paths)
 
         try FileManager.default.createDirectory(
-            at: Configuration.shared.gitMirrorDirectory,
+            at: Paths.gitMirrorStorageDirectory,
             withIntermediateDirectories: true
         )
 
-        let manifestPath = Configuration.shared.gitMirrorDirectory.appendingPathComponent("manifest")
+        let manifestPath = Paths.gitMirrorStorageDirectory.appendingPathComponent("manifest")
         try manifest.data(using: .utf8)?
             .write(to: manifestPath, options: .atomicWrite)
     }

--- a/Sources/hostmgr/commands/sync/SyncAuthorizedKeysCommand.swift
+++ b/Sources/hostmgr/commands/sync/SyncAuthorizedKeysCommand.swift
@@ -31,7 +31,7 @@ struct SyncAuthorizedKeysCommand: AsyncParsableCommand, FollowsCommandPolicies {
         name: .shortAndLong,
         help: "The path to your authorized_keys file on disk (defaults to ~/.ssh/authorized_keys)"
     )
-    var destination: String = Configuration.shared.localAuthorizedKeys
+    var destination: String = Paths.authorizedKeysFilePath.path
 
     @OptionGroup
     var options: SharedSyncOptions

--- a/Sources/libhostmgr/Model/Configuration.swift
+++ b/Sources/libhostmgr/Model/Configuration.swift
@@ -21,34 +21,12 @@ public struct Configuration: Codable {
             .vmImages
         ]
 
-        static var storageRoot: URL {
-            switch ProcessInfo.processInfo.processorArchitecture {
-            case .arm64: return URL(fileURLWithPath: "/opt/homebrew/var")
-            case .x64: return URL(fileURLWithPath: "/usr/local/var")
-            }
-        }
-
-        static var defaultLocalImageStorageDirectory: String {
-            return storageRoot.appendingPathComponent("vm-images").path
-        }
-
-        static var defaultLocalGitMirrorStorageDirectory: String {
-            return storageRoot.appendingPathComponent("git-mirrors").path
-        }
-
         static let defaultGitMirrorPort: UInt = 41362
 
         static let defaultAWSAcceleratedTransferAllowed = true
         static let defaultAWSConfigurationMethod: AWSConfigurationType = .configurationFile
 
         static let defaultAuthorizedKeysRefreshInterval: UInt = 3600
-        static var defaultLocalAuthorizedKeysFilePath: String {
-            FileManager.default
-                .homeDirectoryForCurrentUser
-                .appendingPathComponent(".ssh")
-                .appendingPathComponent("authorized_keys")
-                .path
-        }
     }
 
     public var version = 1
@@ -61,17 +39,14 @@ public struct Configuration: Codable {
 
     /// Images that are protected from deletion (useful for local work, or for a fallback image)
     public var protectedImages: [String] = []
-    public var localImageStorageDirectory: String = Defaults.defaultLocalImageStorageDirectory
 
     /// authorized_keys file sync
     public var authorizedKeysSyncInterval = Defaults.defaultAuthorizedKeysRefreshInterval
     public var authorizedKeysBucket = ""
     public var authorizedKeysRegion: String = SotoS3.Region.useast1.rawValue
-    public var localAuthorizedKeys = Defaults.defaultLocalAuthorizedKeysFilePath
 
     /// git repo mirroring
     public var gitMirrorBucket = ""
-    public var localGitMirrorStorageDirectory = Defaults.defaultLocalGitMirrorStorageDirectory
     public var gitMirrorPort = Defaults.defaultGitMirrorPort
 
     /// settings for running in AWS
@@ -86,15 +61,12 @@ public struct Configuration: Codable {
         case vmImagesRegion
 
         case protectedImages
-        case localImageStorageDirectory
 
         case authorizedKeysSyncInterval
         case authorizedKeysBucket
         case authorizedKeysRegion
-        case localAuthorizedKeys
 
         case gitMirrorBucket
-        case localGitMirrorStorageDirectory
         case gitMirrorPort
 
         case allowAWSAcceleratedTransfer
@@ -117,24 +89,12 @@ public struct Configuration: Codable {
         protectedImages = values.decode(
             forKey: .protectedImages,
             defaultingTo: [])
-        localImageStorageDirectory = values.decode(
-            forKey: .localImageStorageDirectory,
-            defaultingTo: Defaults.defaultLocalImageStorageDirectory
-        )
 
         authorizedKeysSyncInterval = values.decode(forKey: .authorizedKeysSyncInterval, defaultingTo: 3600)
         authorizedKeysBucket = try values.decode(String.self, forKey: .authorizedKeysBucket)
         authorizedKeysRegion = try values.decode(Region.self, forKey: .authorizedKeysRegion).rawValue
-        localAuthorizedKeys = values.decode(
-            forKey: .localAuthorizedKeys,
-            defaultingTo: Defaults.defaultLocalAuthorizedKeysFilePath
-        )
 
         gitMirrorBucket = try values.decode(String.self, forKey: .gitMirrorBucket)
-        localGitMirrorStorageDirectory = values.decode(
-            forKey: .localGitMirrorStorageDirectory,
-            defaultingTo: Defaults.defaultLocalGitMirrorStorageDirectory
-        )
         gitMirrorPort = values.decode(
             forKey: .gitMirrorPort,
             defaultingTo: Defaults.defaultGitMirrorPort
@@ -154,28 +114,20 @@ public struct Configuration: Codable {
 /// Accessor Helpers
 public extension Configuration {
 
-    static var shared: Configuration = (try? StateManager.getConfiguration()) ?? Configuration()
+    static var shared: Configuration = (try? ConfigurationRepository.getConfiguration()) ?? Configuration()
 
     static var isValid: Bool {
-        let configuration = try? StateManager.getConfiguration()
+        let configuration = try? ConfigurationRepository.getConfiguration()
         return configuration != nil
     }
 
     @discardableResult
     func save() throws -> Configuration {
-        return try StateManager.write(configuration: self)
+        return try ConfigurationRepository.write(configuration: self)
     }
 
     static func from(data: Data) throws -> Self {
         try JSONDecoder().decode(Configuration.self, from: data)
-    }
-
-    var vmStorageDirectory: URL {
-        URL(fileURLWithPath: localImageStorageDirectory)
-    }
-
-    var gitMirrorDirectory: URL {
-        URL(fileURLWithPath: localGitMirrorStorageDirectory)
     }
 }
 

--- a/Sources/libhostmgr/Model/ConfigurationRepository.swift
+++ b/Sources/libhostmgr/Model/ConfigurationRepository.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+public struct ConfigurationRepository {
+
+    public static var configurationFileExists: Bool {
+        FileManager.default.fileExists(at: Paths.configurationFilePath)
+    }
+
+    public static func getConfiguration() throws -> Configuration {
+        try FileManager.default.createDirectory(at: Paths.configurationRoot, withIntermediateDirectories: true)
+        let data = try Data(contentsOf: Paths.configurationFilePath)
+        return try Configuration.from(data: data)
+    }
+
+    @discardableResult
+    public static func write(configuration: Configuration) throws -> Configuration {
+        try FileManager.default.createDirectory(at: Paths.configurationRoot, withIntermediateDirectories: true)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .prettyPrinted
+        let data = try encoder.encode(configuration)
+        try data.write(to: Paths.configurationFilePath)
+        return configuration
+    }
+}

--- a/Sources/libhostmgr/Model/ConfigurationRepository.swift
+++ b/Sources/libhostmgr/Model/ConfigurationRepository.swift
@@ -6,19 +6,29 @@ public struct ConfigurationRepository {
         FileManager.default.fileExists(at: Paths.configurationFilePath)
     }
 
-    public static func getConfiguration() throws -> Configuration {
+    public static func createConfigurationDirectoryIfNeeded() throws {
         try FileManager.default.createDirectory(at: Paths.configurationRoot, withIntermediateDirectories: true)
+    }
+
+    public static func getConfiguration() throws -> Configuration {
+        try createConfigurationDirectoryIfNeeded()
         let data = try Data(contentsOf: Paths.configurationFilePath)
         return try Configuration.from(data: data)
     }
 
     @discardableResult
     public static func write(configuration: Configuration) throws -> Configuration {
-        try FileManager.default.createDirectory(at: Paths.configurationRoot, withIntermediateDirectories: true)
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = .prettyPrinted
-        let data = try encoder.encode(configuration)
+        try createConfigurationDirectoryIfNeeded()
+
+        let data = try jsonEncoder.encode(configuration)
         try data.write(to: Paths.configurationFilePath)
+
         return configuration
     }
+
+    private static let jsonEncoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .prettyPrinted
+        return encoder
+    }()
 }

--- a/Sources/libhostmgr/Model/LocalVMRepository.swift
+++ b/Sources/libhostmgr/Model/LocalVMRepository.swift
@@ -29,7 +29,7 @@ public struct LocalVMRepository: LocalVMRepositoryProtocol {
     private let imageDirectory: URL
     private let fileManager: FileManager
 
-    public init(imageDirectory: URL = Configuration.shared.vmStorageDirectory, fileManager: FileManager = .default) {
+    public init(imageDirectory: URL = Paths.vmImageStorageDirectory, fileManager: FileManager = .default) {
         self.imageDirectory = imageDirectory
         self.fileManager = fileManager
     }

--- a/Sources/libhostmgr/Model/Paths.swift
+++ b/Sources/libhostmgr/Model/Paths.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+public struct Paths {
+
+    private static var homebrewRoot: URL {
+        switch ProcessInfo.processInfo.processorArchitecture {
+        case .arm64: return URL(fileURLWithPath: "/opt/homebrew/", isDirectory: true)
+        case .x64: return URL(fileURLWithPath: "/usr/local/", isDirectory: true)
+        }
+    }
+
+    static var storageRoot: URL {
+        homebrewRoot.appendingPathComponent("var", isDirectory: true)
+    }
+
+    static var configurationRoot: URL {
+        homebrewRoot
+            .appendingPathComponent("etc", isDirectory: true)
+            .appendingPathComponent("hostmgr", isDirectory: true)
+    }
+
+    static var stateRoot: URL {
+        storageRoot
+            .appendingPathComponent("hostmgr", isDirectory: true)
+            .appendingPathComponent("state", isDirectory: true)
+    }
+
+    public static var vmImageStorageDirectory: URL {
+        storageRoot.appendingPathComponent("vm-images")
+    }
+
+    public static var gitMirrorStorageDirectory: URL {
+        storageRoot.appendingPathComponent("git-mirrors")
+    }
+
+    public static var authorizedKeysFilePath: URL {
+        FileManager.default
+            .homeDirectoryForCurrentUser
+            .appendingPathComponent(".ssh")
+            .appendingPathComponent("authorized_keys")
+    }
+
+    static var configurationFilePath: URL {
+        configurationRoot.appendingPathComponent("config.json")
+    }
+}

--- a/Sources/libhostmgr/Model/Paths.swift
+++ b/Sources/libhostmgr/Model/Paths.swift
@@ -4,8 +4,8 @@ public struct Paths {
 
     private static var homebrewRoot: URL {
         switch ProcessInfo.processInfo.processorArchitecture {
-        case .arm64: return URL(fileURLWithPath: "/opt/homebrew/", isDirectory: true)
-        case .x64: return URL(fileURLWithPath: "/usr/local/", isDirectory: true)
+        case .arm64: return URL(fileURLWithPath: "/opt/homebrew", isDirectory: true)
+        case .x64: return URL(fileURLWithPath: "/usr/local", isDirectory: true)
         }
     }
 

--- a/Sources/libhostmgr/Model/RemoteVMRepository.swift
+++ b/Sources/libhostmgr/Model/RemoteVMRepository.swift
@@ -60,21 +60,20 @@ public struct RemoteVMRepository {
     @discardableResult
     public func download(
         image: RemoteVMImage,
-        progressCallback: @escaping FileTransferProgressCallback
+        progressCallback: @escaping FileTransferProgressCallback,
+        destinationDirectory: URL
     ) async throws -> URL {
-
-        let destination = Configuration.shared.vmStorageDirectory
 
         // Download the checksum file first
         _ = try await self.s3Manager.download(
             object: image.checksumObject,
-            to: destination.appendingPathComponent(image.checksumFileName),
+            to: destinationDirectory.appendingPathComponent(image.checksumFileName),
             progressCallback: nil
         )
 
         return try await self.s3Manager.download(
             object: image.imageObject,
-            to: destination.appendingPathComponent(image.fileName),
+            to: destinationDirectory.appendingPathComponent(image.fileName),
             progressCallback: progressCallback
         )
     }

--- a/Sources/libhostmgr/libhostmgr.swift
+++ b/Sources/libhostmgr/libhostmgr.swift
@@ -32,7 +32,7 @@ public func downloadRemoteImage(
 public func downloadRemoteImage(
     _ remoteImage: RemoteVMImage,
     remoteRepository: RemoteVMRepository = RemoteVMRepository(),
-    storageDirectory: URL = Configuration.shared.vmStorageDirectory
+    storageDirectory: URL = Paths.vmImageStorageDirectory
 ) async throws -> URL {
 
     // If this is the first run, the storage directory may not exist, so we'll create it just in case
@@ -55,7 +55,8 @@ public func downloadRemoteImage(
     let progressBar = Console.startImageDownload(remoteImage)
     let destination = try await remoteRepository.download(
         image: remoteImage,
-        progressCallback: progressBar.update
+        progressCallback: progressBar.update,
+        destinationDirectory: storageDirectory
     )
 
     Console.success("Download Complete")

--- a/Tests/libhostmgrTests/ConfigurationTests.swift
+++ b/Tests/libhostmgrTests/ConfigurationTests.swift
@@ -11,14 +11,6 @@ final class ConfigurationTests: XCTestCase {
         )
 
         XCTAssertEqual(
-            Configuration().localImageStorageDirectory,
-            Configuration.Defaults.defaultLocalImageStorageDirectory
-        )
-        XCTAssertEqual(
-            Configuration().localGitMirrorStorageDirectory,
-            Configuration.Defaults.defaultLocalGitMirrorStorageDirectory
-        )
-        XCTAssertEqual(
             Configuration().gitMirrorPort,
             Configuration.Defaults.defaultGitMirrorPort
         )
@@ -29,11 +21,6 @@ final class ConfigurationTests: XCTestCase {
         XCTAssertEqual(
             Configuration().awsConfigurationMethod,
             Configuration.Defaults.defaultAWSConfigurationMethod
-        )
-
-        XCTAssertEqual(
-            Configuration().localAuthorizedKeys,
-            Configuration.Defaults.defaultLocalAuthorizedKeysFilePath
         )
     }
 
@@ -47,35 +34,17 @@ final class ConfigurationTests: XCTestCase {
         let data = getJSONDataForResource(named: "0.6.0")
         let configuration = try Configuration.from(data: data)
         XCTAssertEqual("authorized-keys-bucket", configuration.authorizedKeysBucket)
-        XCTAssertEqual("authorized-keys-path", configuration.localAuthorizedKeys)
         XCTAssertEqual(123456, configuration.authorizedKeysSyncInterval)
         XCTAssertEqual("us-east-2", configuration.authorizedKeysRegion)
 
         XCTAssertEqual("vm-images-bucket", configuration.vmImagesBucket)
         XCTAssertEqual("us-east-2", configuration.vmImagesRegion)
-        XCTAssertEqual("image-storage-dir", configuration.localImageStorageDirectory)
 
-        XCTAssertEqual("git-mirror-storage-dir", configuration.localGitMirrorStorageDirectory)
         XCTAssertEqual("git-mirror-bucket", configuration.gitMirrorBucket)
         XCTAssertEqual(123456, configuration.gitMirrorPort)
 
         XCTAssertEqual(["foo-bar-baz"], configuration.protectedImages)
         XCTAssertEqual([.vmImages], configuration.syncTasks)
-    }
-
-    func testThatConfigurationWithoutLocalImageStorageDirectoryUsesDefault() throws {
-        let data = getJSONDataForResource(named: "defaults")
-        let configuration = try Configuration.from(data: data)
-        XCTAssertEqual(Configuration.Defaults.defaultLocalImageStorageDirectory, configuration.vmStorageDirectory.path)
-    }
-
-    func testThatConfigurationWithoutLocalGitMirrorStorageDirectoryUsesDefault() throws {
-        let data = getJSONDataForResource(named: "defaults")
-        let configuration = try Configuration.from(data: data)
-        XCTAssertEqual(
-            Configuration.Defaults.defaultLocalGitMirrorStorageDirectory,
-            configuration.gitMirrorDirectory.path
-        )
     }
 
     func testThatConfigurationWithoutLocalGitMirrorPortUsesDefault() throws {

--- a/Tests/libhostmgrTests/Model/PathsTests.swift
+++ b/Tests/libhostmgrTests/Model/PathsTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+@testable import libhostmgr
+
+final class PathsTests: XCTestCase {
+
+    func testThatStorageRootIsCorrect() {
+        validate(path: Paths.storageRoot, resolvesTo: "/usr/local/var", forArchitecture: .x64)
+        validate(path: Paths.storageRoot, resolvesTo: "/opt/homebrew/var", forArchitecture: .arm64)
+    }
+
+    func testThatConfigurationRootIsCorrect() {
+        validate(path: Paths.configurationRoot, resolvesTo: "/usr/local/etc/hostmgr", forArchitecture: .x64)
+        validate(path: Paths.configurationRoot, resolvesTo: "/opt/homebrew/etc/hostmgr", forArchitecture: .arm64)
+    }
+
+    func testThatStateRootIsCorrect() {
+        validate(path: Paths.stateRoot, resolvesTo: "/usr/local/var/hostmgr/state", forArchitecture: .x64)
+        validate(path: Paths.stateRoot, resolvesTo: "/opt/homebrew/var/hostmgr/state", forArchitecture: .arm64)
+    }
+
+    func testThatVMStoragePathIsCorrect() {
+        validate(path: Paths.vmImageStorageDirectory, resolvesTo: "/usr/local/var/vm-images", forArchitecture: .x64)
+        validate(path: Paths.vmImageStorageDirectory, resolvesTo: "/opt/homebrew/vm-images", forArchitecture: .arm64)
+    }
+
+    func testThatGitMirrorStoragePathIsCorrect() {
+        let path = Paths.gitMirrorStorageDirectory
+        validate(path: path, resolvesTo: "/usr/local/var/git-mirrors", forArchitecture: .x64)
+        validate(path: path, resolvesTo: "/opt/homebrew/git-mirrors", forArchitecture: .arm64)
+    }
+
+    @available(macOS 13.0, *)
+    func testThatAuthorizedKeysFilePathIsCorrect() {
+        let resolvedPath = NSHomeDirectory() + "/.ssh/authorized_keys"
+        validate(path: Paths.authorizedKeysFilePath, resolvesTo: resolvedPath)
+    }
+
+    func testThatConfigurationFilePathIsCorrect() {
+        let path = Paths.configurationFilePath
+        validate(path: path, resolvesTo: "/usr/local/etc/hostmgr/config.json", forArchitecture: .x64)
+        validate(path: path, resolvesTo: "/opt/homebrew/etc/hostmgr/config.json", forArchitecture: .arm64)
+    }
+
+    private func validate(
+        path: URL,
+        resolvesTo sample: String,
+        forArchitecture arch: ProcessorArchitecture? = nil,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        guard arch != nil && arch == ProcessInfo.processInfo.processorArchitecture else {
+            return
+        }
+
+        XCTAssertEqual(URL(fileURLWithPath: sample), path, file: file, line: line)
+    }
+
+}

--- a/Tests/libhostmgrTests/Model/PathsTests.swift
+++ b/Tests/libhostmgrTests/Model/PathsTests.swift
@@ -52,7 +52,7 @@ final class PathsTests: XCTestCase {
             return
         }
 
-        XCTAssertEqual(URL(fileURLWithPath: sample), path, file: file, line: line)
+        XCTAssertEqual(sample, path.path, file: file, line: line)
     }
 
 }


### PR DESCRIPTION
Refactors the `Configuration` object to move File System paths into a new `Paths` struct – this makes it so that paths are no longer user-configurable, but it also moves us closer to not requiring a configuration file at all.

Part of the path to catching up the `trunk` branch with [the 0.15.13 release](https://github.com/Automattic/hostmgr/releases/tag/0.15.13).