### PR TITLE
Remove SotoS3 and Alamofire

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,24 +1,6 @@
 {
   "pins" : [
     {
-      "identity" : "alamofire",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Alamofire/Alamofire.git",
-      "state" : {
-        "revision" : "8dd85aee02e39dd280c75eef88ffdb86eed4b07b",
-        "version" : "5.6.2"
-      }
-    },
-    {
-      "identity" : "async-http-client",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swift-server/async-http-client.git",
-      "state" : {
-        "revision" : "794dc9d42720af97cedd395e8cd2add9173ffd9a",
-        "version" : "1.11.1"
-      }
-    },
-    {
       "identity" : "console-kit",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/console-kit.git",
@@ -34,15 +16,6 @@
       "state" : {
         "revision" : "1f15bb9de727d694af1d003a1a5d7a553752850f",
         "version" : "3.0.0"
-      }
-    },
-    {
-      "identity" : "jmespath.swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/adam-fowler/jmespath.swift.git",
-      "state" : {
-        "revision" : "4513d319c4aaa6c3b2ac18e1e6566a803515ad91",
-        "version" : "1.0.2"
       }
     },
     {
@@ -73,30 +46,21 @@
       }
     },
     {
-      "identity" : "soto",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/soto-project/soto.git",
-      "state" : {
-        "revision" : "9c938aadbbb33d6ed54d04dd6ba494f7f12e0905",
-        "version" : "6.0.0"
-      }
-    },
-    {
-      "identity" : "soto-core",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/soto-project/soto-core.git",
-      "state" : {
-        "revision" : "8e63c0f80db61f01c346f5109863bc2be29093e7",
-        "version" : "6.0.0"
-      }
-    },
-    {
       "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser",
       "state" : {
         "revision" : "9f39744e025c7d377987f30b03770805dcb0bcd1",
         "version" : "1.1.4"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "9cc89f0170308b813af05dadcd26f9a2dee47713",
+        "version" : "2.2.3"
       }
     },
     {
@@ -109,57 +73,12 @@
       }
     },
     {
-      "identity" : "swift-metrics",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-metrics.git",
-      "state" : {
-        "revision" : "3edd2f57afc4e68e23c3e4956bc8b65ca6b5b2ff",
-        "version" : "2.2.0"
-      }
-    },
-    {
       "identity" : "swift-nio",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
         "revision" : "124119f0bb12384cef35aa041d7c3a686108722d",
         "version" : "2.40.0"
-      }
-    },
-    {
-      "identity" : "swift-nio-extras",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio-extras.git",
-      "state" : {
-        "revision" : "f73ca5ee9c6806800243f1ac415fcf82de9a4c91",
-        "version" : "1.10.2"
-      }
-    },
-    {
-      "identity" : "swift-nio-http2",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio-http2.git",
-      "state" : {
-        "revision" : "108ac15087ea9b79abb6f6742699cf31de0e8772",
-        "version" : "1.22.0"
-      }
-    },
-    {
-      "identity" : "swift-nio-ssl",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio-ssl.git",
-      "state" : {
-        "revision" : "5e68c1ded15619bb281b273fa8c2d8fd7f7b2b7d",
-        "version" : "2.16.1"
-      }
-    },
-    {
-      "identity" : "swift-nio-transport-services",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio-transport-services.git",
-      "state" : {
-        "revision" : "2cb54f91ddafc90832c5fa247faf5798d0a7c204",
-        "version" : "1.13.0"
       }
     },
     {
@@ -178,6 +97,15 @@
       "state" : {
         "revision" : "b7667f3e266af621e5cc9c77e74cacd8e8c00cb4",
         "version" : "0.2.5"
+      }
+    },
+    {
+      "identity" : "tinys3",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jkmassel/tinys3.git",
+      "state" : {
+        "branch" : "main",
+        "revision" : "31b1568aa7ab6354b42cd8b344fbb5bc57c1620c"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -11,13 +11,12 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.1.4"),
-        .package(url: "https://github.com/soto-project/soto.git", from: "6.0.0"),
-        .package(url: "https://github.com/jkmassel/prlctl.git", from: "1.21.0"),
+        .package(url: "https://github.com/jkmassel/tinys3.git", branch: "main"),
+        .package(url: "https://github.com/jkmassel/prlctl.git", from: "1.22.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/jkmassel/kcpassword-swift.git", from: "1.0.0"),
         .package(url: "https://github.com/swiftpackages/DotEnv.git", from: "3.0.0"),
         .package(url: "https://github.com/apple/swift-tools-support-core", from: "0.2.5"),
-        .package(url: "https://github.com/Alamofire/Alamofire.git", .upToNextMajor(from: "5.6.1")),
         .package(url: "https://github.com/vapor/console-kit.git", .upToNextMajor(from: "4.5.0")),
     ],
     targets: [
@@ -36,9 +35,8 @@ let package = Package(
             name: "libhostmgr",
             dependencies: [
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
-                .product(name: "SotoS3", package: "soto"),
                 .product(name: "TSCBasic", package: "swift-tools-support-core"),
-                .product(name: "Alamofire", package: "Alamofire"),
+                .product(name: "tinys3", package: "tinys3"),
                 .product(name: "ConsoleKit", package: "console-kit"),
                 .product(name: "prlctl", package: "prlctl"),
             ]

--- a/Sources/libhostmgr/CLI/Console.swift
+++ b/Sources/libhostmgr/CLI/Console.swift
@@ -1,5 +1,6 @@
 import Foundation
 import ConsoleKit
+import tinys3
 
 public struct Console {
 

--- a/Sources/libhostmgr/Model/Configuration.swift
+++ b/Sources/libhostmgr/Model/Configuration.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SotoS3
 import ArgumentParser
 
 public struct Configuration: Codable {
@@ -35,7 +34,7 @@ public struct Configuration: Codable {
 
     /// VM Remote Image Settings
     public var vmImagesBucket: String = ""
-    public var vmImagesRegion: String = SotoS3.Region.useast1.rawValue
+    public var vmImagesRegion: String = "us-east-1"
 
     /// Images that are protected from deletion (useful for local work, or for a fallback image)
     public var protectedImages: [String] = []
@@ -43,7 +42,7 @@ public struct Configuration: Codable {
     /// authorized_keys file sync
     public var authorizedKeysSyncInterval = Defaults.defaultAuthorizedKeysRefreshInterval
     public var authorizedKeysBucket = ""
-    public var authorizedKeysRegion: String = SotoS3.Region.useast1.rawValue
+    public var authorizedKeysRegion: String = "us-east-1"
 
     /// git repo mirroring
     public var gitMirrorBucket = ""
@@ -84,7 +83,7 @@ public struct Configuration: Codable {
         )
 
         vmImagesBucket = try values.decode(String.self, forKey: .vmImagesBucket)
-        vmImagesRegion = try values.decode(Region.self, forKey: .vmImagesRegion).rawValue
+        vmImagesRegion = try values.decode(String.self, forKey: .vmImagesRegion)
 
         protectedImages = values.decode(
             forKey: .protectedImages,
@@ -92,7 +91,7 @@ public struct Configuration: Codable {
 
         authorizedKeysSyncInterval = values.decode(forKey: .authorizedKeysSyncInterval, defaultingTo: 3600)
         authorizedKeysBucket = try values.decode(String.self, forKey: .authorizedKeysBucket)
-        authorizedKeysRegion = try values.decode(Region.self, forKey: .authorizedKeysRegion).rawValue
+        authorizedKeysRegion = try values.decode(String.self, forKey: .authorizedKeysRegion)
 
         gitMirrorBucket = try values.decode(String.self, forKey: .gitMirrorBucket)
         gitMirrorPort = values.decode(

--- a/Sources/libhostmgr/Model/RemoteVMImage.swift
+++ b/Sources/libhostmgr/Model/RemoteVMImage.swift
@@ -1,44 +1,28 @@
 import Foundation
+import tinys3
 
 public struct RemoteVMImage: FilterableByBasename {
     public let imageObject: S3Object
     public let checksumObject: S3Object
 
-    public var imagePath: String {
-        imageObject.key
-    }
-
     public var fileName: String {
-        URL(fileURLWithPath: imagePath)
+        URL(fileURLWithPath: imageObject.key)
             .lastPathComponent
     }
 
     public var basename: String {
-        URL(fileURLWithPath: imagePath)
+        URL(fileURLWithPath: imageObject.key)
             .deletingPathExtension()
             .lastPathComponent
-    }
-
-    public var checksumKey: String {
-        checksumObject.key
     }
 
     public var checksumFileName: String {
         basename + ".sha256.txt"
     }
-
-    public init(imageObject: S3Object, checksumKey: String) {
-        self.imageObject = imageObject
-        self.checksumObject = S3Object(
-            key: checksumKey,
-            size: 64, // Checksums are always 64 bytes
-            modifiedAt: .now
-        )
-    }
 }
 
 extension RemoteVMImage: Equatable {
     public static func == (lhs: RemoteVMImage, rhs: RemoteVMImage) -> Bool {
-        lhs.imageObject == rhs.imageObject && lhs.checksumKey == rhs.checksumKey
+        lhs.imageObject == rhs.imageObject && lhs.checksumObject == rhs.checksumObject
     }
 }

--- a/Sources/libhostmgr/Model/RemoteVMRepository.swift
+++ b/Sources/libhostmgr/Model/RemoteVMRepository.swift
@@ -101,8 +101,7 @@ public struct RemoteVMRepository {
             .filter { $0.key.hasSuffix(".sha256.txt") }
             .sorted()
 
-        return zip(imageObjects, checksums).reduce(into: [RemoteVMImage]()) {
-            $0.append(RemoteVMImage(imageObject: $1.0, checksumObject: $1.1))
-        }
+        return zip(imageObjects, checksums)
+            .map { RemoteVMImage(imageObject: $0, checksumObject: $1) }
     }
 }

--- a/Sources/libhostmgr/Model/RemoteVMRepository.swift
+++ b/Sources/libhostmgr/Model/RemoteVMRepository.swift
@@ -1,4 +1,5 @@
 import Foundation
+import tinys3
 
 public struct RemoteVMRepository {
 
@@ -24,17 +25,23 @@ public struct RemoteVMRepository {
         }
 
         func sortByDateDescending(_ lhs: RemoteVMImage, _ rhs: RemoteVMImage) -> Bool {
-            lhs.imageObject.modifiedAt > rhs.imageObject.modifiedAt
+            lhs.imageObject.lastModifiedAt > rhs.imageObject.lastModifiedAt
         }
     }
 
     private let s3Manager: S3ManagerProtocol
 
-    public init(s3Manager: S3ManagerProtocol? = nil) {
+    public init(s3Manager: S3ManagerProtocol? = nil) throws {
         let bucket: String = Configuration.shared.vmImagesBucket
         let region: String = Configuration.shared.vmImagesRegion
+        let credentials = try AWSCredentials.fromUserConfiguration()
 
-        self.s3Manager = s3Manager ?? S3Manager(bucket: bucket, region: region)
+        self.s3Manager = try s3Manager ?? S3Manager(
+            bucket: bucket,
+            region: region,
+            credentials: credentials,
+            endpoint: .accelerated
+        )
     }
 
     public func getManifest() async throws -> [String] {
@@ -57,25 +64,27 @@ public struct RemoteVMRepository {
 
     /// Downloads a remote image using atomic writes to avoid conflict with existing files or other processes
     ///
-    @discardableResult
     public func download(
         image: RemoteVMImage,
-        progressCallback: @escaping FileTransferProgressCallback,
-        destinationDirectory: URL
+        destinationDirectory: URL,
+        progressCallback: @escaping FileTransferProgressCallback
     ) async throws -> URL {
 
         // Download the checksum file first
-        _ = try await self.s3Manager.download(
-            object: image.checksumObject,
+       try await self.s3Manager.download(
+            key: image.checksumObject.key,
             to: destinationDirectory.appendingPathComponent(image.checksumFileName),
-            progressCallback: nil
-        )
+            progressCallback: nil)
 
-        return try await self.s3Manager.download(
-            object: image.imageObject,
-            to: destinationDirectory.appendingPathComponent(image.fileName),
+        let imageFileDestination = destinationDirectory.appendingPathComponent(image.checksumFileName)
+
+        try await self.s3Manager.download(
+            key: image.imageObject.key,
+            to: destinationDirectory.appendingPathComponent(image.checksumFileName),
             progressCallback: progressCallback
         )
+
+        return imageFileDestination
     }
 
     public func listImages(sortedBy strategy: RemoteVMImageSortingStrategy = .name) async throws -> [RemoteVMImage] {
@@ -86,22 +95,14 @@ public struct RemoteVMRepository {
     func remoteImagesFrom(objects: [S3Object]) -> [RemoteVMImage] {
         let imageObjects = objects
             .filter { $0.key.hasSuffix(".pvmp") }
+            .sorted()
 
         let checksums = objects
             .filter { $0.key.hasSuffix(".sha256.txt") }
-            .map(\.key)
+            .sorted()
 
-        return imageObjects.compactMap { object in
-            let filename = URL(fileURLWithPath: object.key).lastPathComponent  // filename = my-image.pvmp
-            let basename = (filename as NSString).deletingPathExtension        // basename = my-image
-
-            let checksumKey = "images/" + basename + ".sha256.txt"
-
-            guard checksums.contains(checksumKey) else {
-                return nil
-            }
-
-            return RemoteVMImage(imageObject: object, checksumKey: checksumKey)
+        return zip(imageObjects, checksums).reduce(into: [RemoteVMImage]()) {
+            $0.append(RemoteVMImage(imageObject: $1.0, checksumObject: $1.1))
         }
     }
 }

--- a/Sources/libhostmgr/S3Manager.swift
+++ b/Sources/libhostmgr/S3Manager.swift
@@ -1,17 +1,18 @@
 import Foundation
-import Alamofire
-import SotoS3
+import CryptoKit
+import tinys3
 
 public typealias FileTransferProgressCallback = (Progress) -> Void
 
 public protocol S3ManagerProtocol {
-    func listObjects(startingWith prefix: String?) async throws -> [S3Object]
+    func listObjects(startingWith prefix: String) async throws -> [S3Object]
     func lookupObject(atPath path: String) async throws -> S3Object?
-    @discardableResult func download(
-        object: S3Object,
+
+    func download(
+        key: String,
         to destination: URL,
         progressCallback: FileTransferProgressCallback?
-    ) async throws -> URL
+    ) async throws
 
     func download(object: S3Object) async throws -> Data?
 }
@@ -21,172 +22,37 @@ public struct S3Manager: S3ManagerProtocol {
     private let bucket: String
     private let region: String
 
-    public init(bucket: String, region: String) {
+    private let s3Client: S3Client
+
+    public init(bucket: String, region: String, credentials: AWSCredentials, endpoint: S3Endpoint) throws {
         self.bucket = bucket
         self.region = region
+        self.s3Client = S3Client(credentials: credentials, endpoint: endpoint)
     }
 
-    public func listObjects(startingWith prefix: String? = nil) async throws -> [S3Object] {
-        try await withS3Client {
-            let request = SotoS3.S3.ListObjectsV2Request(
-                bucket: self.bucket,
-                maxKeys: 1000,
-                prefix: prefix
-            )
-
-            let response = try await $0.listObjectsV2(request)
-            guard let objects = response.contents else {
-                return []
-            }
-
-            return objects.compactMap { S3Object.from($0) }
-        }
+    public func listObjects(startingWith prefix: String = "") async throws -> [S3Object] {
+        try await s3Client.list(bucket: self.bucket, prefix: prefix).objects
     }
 
     public func lookupObject(atPath path: String) async throws -> S3Object? {
-        try await withS3Client {
-            let request =  SotoS3.S3.HeadObjectRequest(bucket: bucket, key: path)
-            let result = try await $0.headObject(request)
-
-            return .from(result, withKey: path)
-        }
+        try await s3Client.head(bucket: self.bucket, key: path).s3Object
     }
 
-    @discardableResult
     public func download(
-        object: S3Object,
+        key: String,
         to destination: URL,
         progressCallback: FileTransferProgressCallback?
-    ) async throws -> URL {
-
-        let signedURL = try await presignedUrl(forObject: object)
-
-        let destinationResolver: DownloadRequest.Destination = { _, _ in
-            (destination, [.createIntermediateDirectories, .removePreviousFile])
-        }
-
-        return try await AF
-            .download(signedURL, method: .get, to: destinationResolver)
-            .downloadProgress { progressCallback?($0) }
-            .serializingDownloadedFileURL(automaticallyCancelling: true)
-            .value
+    ) async throws {
+        let tempUrl = try await s3Client.download(
+            objectWithKey: key,
+            inBucket: self.bucket,
+            progressCallback: progressCallback
+        )
+        try FileManager.default.moveItem(at: tempUrl, to: destination)
     }
 
     public func download(object: S3Object) async throws -> Data? {
-        let signedURL = try await presignedUrl(forObject: object)
-        return await AF.request(signedURL, method: .get)
-            .validate()
-            .serializingData()
-            .response
-            .value
-    }
-
-    private func presignedUrl(forObject object: S3Object) async throws -> URL {
-        try await withS3Client {
-            var unsignedUrl = URL(string: "https://\(bucket).s3.\(region).amazonaws.com/\(object.key)")!
-
-            if try await bucketSupportsAcceleratedDownload {
-                unsignedUrl = URL(string: "https://\(bucket).s3-accelerate.amazonaws.com/\(object.key)")!
-            }
-
-            return try await $0.signURL(
-                url: unsignedUrl,
-                httpMethod: .GET,
-                expires: .hours(24)
-            )
-        }
-    }
-
-    private var bucketSupportsAcceleratedDownload: Bool {
-        get async throws {
-            try await withS3Client {
-                let request = SotoS3.S3.GetBucketAccelerateConfigurationRequest(bucket: self.bucket)
-                let response = try await $0.getBucketAccelerateConfiguration(request)
-                return response.status == .enabled
-            }
-        }
-    }
-
-    private func withS3Client<T>(_ block: (SotoS3.S3) async throws -> T) async throws -> T {
-        let awsClient = AWSClient(credentialProvider: credentialProvider, httpClientProvider: .createNew)
-        let s3Client = SotoS3.S3(client: awsClient, region: Region(rawValue: self.region))
-
-        // The following code `try await` the given operation to execute with a
-        // `SotoS3.S3` client created ad hoc and, once done, shuts down that
-        // client.
-        //
-        // If something goes wrong while running the block, we still need to
-        // shutdown the client, else the error from the block will be lost and
-        // the program will fail with something like:
-        //
-        // SotoCore/AWSClient.swift:110: Assertion failed:
-        //   AWSClient not shut down before the deinit.
-        //   Please call client.syncShutdown() when no longer needed.
-        //
-        // It would be good to use `defer`, but it doesn't yet support asycn.
-        // See https://forums.swift.org/t/async-rethrows-and-defer/58356.
-        //
-        // So, we use a `do catch` where in the catch we first shutdown the
-        // client and then bubble up the error.
-        let result: T
-        do {
-            result = try await block(s3Client)
-        } catch {
-            try await awsClient.shutdown()
-            throw error
-        }
-
-        // We need to shutdown the client also when `block` run successfully.
-        //
-        // This duplication with the call above will disappear once Swift will
-        // give us a way to call `defer`.
-        try await awsClient.shutdown()
-
-        return result
-    }
-
-    private var credentialProvider: CredentialProviderFactory {
-        switch Configuration.shared.awsConfigurationMethod {
-        case .configurationFile: return .configFile()
-        case .ec2Environment: return .ec2
-        case .none: return .configFile()
-        }
-    }
-}
-
-public struct S3Object: Equatable {
-    public let key: String
-    public let size: Int
-    public let modifiedAt: Date
-
-    public init(key: String, size: Int, modifiedAt: Date) {
-        self.key = key
-        self.size = size
-        self.modifiedAt = modifiedAt
-    }
-
-    static func from(_ object: SotoS3.S3.Object) -> S3Object? {
-        guard
-            let key = object.key,
-            let size = object.size,
-            let date = object.lastModified
-        else { return nil }
-
-        return S3Object(key: key, size: Int(size), modifiedAt: date)
-    }
-
-    static func from(_ result: SotoS3.S3.HeadObjectOutput, withKey key: String) -> S3Object? {
-        guard
-            let size = result.contentLength,
-            let date = result.lastModified
-        else {
-            return nil
-        }
-
-        return S3Object(
-            key: key,
-            size: Int(size),
-            modifiedAt: date
-        )
+        let downloadUrl = s3Client.signedDownloadUrl(forKey: object.key, in: self.bucket, validFor: 60)
+        return try await URLSession.shared.data(from: downloadUrl).0
     }
 }

--- a/Sources/libhostmgr/libhostmgr.swift
+++ b/Sources/libhostmgr/libhostmgr.swift
@@ -16,8 +16,9 @@ public func fetchRemoteImage(name: String) async throws {
 @discardableResult
 public func downloadRemoteImage(
     name: String,
-    remoteRepository: RemoteVMRepository = RemoteVMRepository()
+    remoteRepository: RemoteVMRepository? = nil
 ) async throws -> URL {
+    let remoteRepository = try remoteRepository ?? RemoteVMRepository()
     guard let remoteImage = try await remoteRepository.getImage(named: name) else {
         Console.crash(message: "Unable to find remote image: \(name)", reason: .unableToFindRemoteImage)
     }
@@ -31,7 +32,7 @@ public func downloadRemoteImage(
 @discardableResult
 public func downloadRemoteImage(
     _ remoteImage: RemoteVMImage,
-    remoteRepository: RemoteVMRepository = RemoteVMRepository(),
+    remoteRepository: RemoteVMRepository? = nil,
     storageDirectory: URL = Paths.vmImageStorageDirectory
 ) async throws -> URL {
 
@@ -53,10 +54,12 @@ public func downloadRemoteImage(
     }
 
     let progressBar = Console.startImageDownload(remoteImage)
+
+    let remoteRepository = try remoteRepository ?? RemoteVMRepository()
     let destination = try await remoteRepository.download(
         image: remoteImage,
-        progressCallback: progressBar.update,
-        destinationDirectory: storageDirectory
+        destinationDirectory: storageDirectory,
+        progressCallback: progressBar.update
     )
 
     Console.success("Download Complete")
@@ -144,8 +147,9 @@ public func deleteLocalImages(
 public func listAvailableRemoteImages(
     sortedBy strategy: RemoteVMRepository.RemoteVMImageSortingStrategy = .newest,
     localRepository: LocalVMRepository = LocalVMRepository(),
-    remoteRepository: RemoteVMRepository = RemoteVMRepository()
+    remoteRepository: RemoteVMRepository? = nil
 ) async throws -> [RemoteVMImage] {
+    let remoteRepository = try remoteRepository ?? RemoteVMRepository()
     let manifest = try await remoteRepository.getManifest()
     let remoteImages = try await remoteRepository.listImages(sortedBy: strategy)
     let localImages = try localRepository.list()
@@ -159,8 +163,9 @@ public func listAvailableRemoteImages(
 ///
 public func listLocalImagesToDelete(
     localRepository: LocalVMRepository = LocalVMRepository(),
-    remoteRepository: RemoteVMRepository = RemoteVMRepository()
+    remoteRepository: RemoteVMRepository? = nil
 ) async throws -> [LocalVMImage] {
+    let remoteRepository = try remoteRepository ?? RemoteVMRepository()
     let manifest = try await remoteRepository.getManifest()
     let localImages = try localRepository.list()
 

--- a/Tests/libhostmgrTests/RemoteVMImageTests.swift
+++ b/Tests/libhostmgrTests/RemoteVMImageTests.swift
@@ -1,15 +1,28 @@
 import XCTest
 @testable import libhostmgr
+@testable import tinys3
 
 final class RemoteVMImageTests: XCTestCase {
 
     private let testSubject = RemoteVMImage(
-        imageObject: S3Object(key: "foo/bar.txt", size: 1234, modifiedAt: Date.distantPast),
-        checksumKey: "foo/bar.sha1.txt"
+        imageObject: S3Object(
+            key: "foo/bar.txt",
+            size: 1234,
+            eTag: "",
+            lastModifiedAt: Date.distantPast,
+            storageClass: ""
+        ),
+        checksumObject: S3Object(
+            key: "foo/bar.sha1.txt",
+            size: 64,
+            eTag: "",
+            lastModifiedAt: Date.distantPast,
+            storageClass: ""
+        )
     )
 
     func testThatImagePathIsValid() throws {
-        XCTAssertEqual("foo/bar.txt", testSubject.imagePath)
+        XCTAssertEqual("foo/bar.txt", testSubject.imageObject.key)
     }
 
     func testThatFileNameIsValid() throws {
@@ -25,6 +38,6 @@ final class RemoteVMImageTests: XCTestCase {
     }
 
     func testThatChecksumCanBeRetrieved() throws {
-        XCTAssertEqual("foo/bar.sha1.txt", testSubject.checksumKey)
+        XCTAssertEqual("foo/bar.sha1.txt", testSubject.checksumObject.key)
     }
 }

--- a/Tests/libhostmgrTests/TestHelpers.swift
+++ b/Tests/libhostmgrTests/TestHelpers.swift
@@ -1,5 +1,6 @@
 import Foundation
 @testable import libhostmgr
+@testable import tinys3
 
 extension RemoteVMImage {
     static func with(
@@ -7,9 +8,17 @@ extension RemoteVMImage {
         size: Int = Int.random(in: 0...Int.max),
         checksumKey: String = UUID().uuidString
     ) -> RemoteVMImage {
-        RemoteVMImage(
-            imageObject: S3Object(key: key, size: size, modifiedAt: Date.distantPast),
-            checksumKey: checksumKey
+        let image = S3Object(key: key, size: size, eTag: "", lastModifiedAt: Date.distantPast, storageClass: "")
+        let checksum = S3Object(
+            key: checksumKey,
+            size: 64,
+            eTag: "",
+            lastModifiedAt: Date.distantPast,
+            storageClass: ""
+        )
+        return RemoteVMImage(
+            imageObject: image,
+            checksumObject: checksum
         )
     }
 }


### PR DESCRIPTION
Removes SotoS3 and Alamofire, replacing them with [the `TinyS3` library](https://github.com/jkmassel/tinys3). TinyS3 has far fewer dependencies, and allows implementing download multiplexing/s3 passthrough caching (as well as removing SwiftNIO/atomics/collections – this reduces the binary size and compile times dramatically).

To test:

1. Try downloading an image using `vm fetch`
2. Try running `authorized_keys` sync (don't forget to delete the file after testing)