### PR TITLE
Ensure the git mirrors manifest contains the most recent caches

### DIFF
--- a/Sources/hostmgr/commands/generate/GenerateGitMirrorManifestCommand.swift
+++ b/Sources/hostmgr/commands/generate/GenerateGitMirrorManifestCommand.swift
@@ -17,10 +17,7 @@ struct GenerateGitMirrorManifestCommand: ParsableCommand {
 
 struct GenerateGitMirrorManifestTask {
     func run() throws {
-        let paths = FileManager.default
-            .subpaths(at: Paths.gitMirrorStorageDirectory)
-
-        let manifest = generateTextManifest(fromPaths: paths)
+        let manifest = try gitMirrorsManifest()
 
         try FileManager.default.createDirectory(
             at: Paths.gitMirrorStorageDirectory,
@@ -30,27 +27,6 @@ struct GenerateGitMirrorManifestTask {
         let manifestPath = Paths.gitMirrorStorageDirectory.appendingPathComponent("manifest")
         try manifest.data(using: .utf8)?
             .write(to: manifestPath, options: .atomicWrite)
-    }
-
-    func generateTextManifest(fromPaths paths: [String]) -> String {
-        paths
-            // By using the `.git.tar` suffix, we avoid files that are currently being
-            // copied (which could look like: `2021-07-19.git.tar.e963f487`)
-            .filter { $0.hasSuffix(".git.tar") }
-            .reduce([String: String](), flatten)
-            .map { $0.key + $0.value }
-            .sorted()
-            .joined(separator: "\n")
-    }
-
-    func flatten(_ dict: [String: String], path: String) -> [String: String] {
-        var dict = dict
-        let fileName = URL(fileURLWithPath: path).lastPathComponent
-        let key = path.replacingOccurrences(of: fileName, with: "")
-
-        dict[key] = fileName
-
-        return dict
     }
 
 }

--- a/Sources/libhostmgr/libhostmgr.swift
+++ b/Sources/libhostmgr/libhostmgr.swift
@@ -333,7 +333,7 @@ extension FileSystem {
         let gitMirrors = files.filter { $0.hasSuffix(".git.tar") }
         let directories = files.filter { isDirectory(path.appending(component: $0)) }
 
-        // git repo cahce files are named as "<year>-<month>-<day>.git.tar".
+        // git repo cache files are named as "<year>-<month>-<day>.git.tar".
         // The "max" one is the most recent.
         let allGitMirrors = gitMirrors.max().flatMap { [path.appending(component: $0)] } ?? []
         return try directories.reduce(into: allGitMirrors, { partialResult, relativePath in

--- a/Tests/libhostmgrTests/GitMirrorTests.swift
+++ b/Tests/libhostmgrTests/GitMirrorTests.swift
@@ -1,0 +1,65 @@
+import Foundation
+import TSCBasic
+import XCTest
+import libhostmgr
+
+class GitMirrorTests: XCTestCase {
+
+    func testManifestAreSorted() throws {
+        let manifest = try getManifest(withFiles: [
+            "automattic/day-one-apple/2023-03-28.git.tar",
+            "automattic/pocket-casts-ios/2023-03-28.git.tar",
+            "automattic/simplenote-ios/2023-03-28.git.tar"
+        ])
+
+        XCTAssertEqual(
+            manifest,
+            """
+            automattic/day-one-apple/2023-03-28.git.tar
+            automattic/pocket-casts-ios/2023-03-28.git.tar
+            automattic/simplenote-ios/2023-03-28.git.tar
+            """
+        )
+    }
+
+    func testManifestOnlyContainsTarFiles() throws {
+        let manifest = try getManifest(withFiles: [
+            "automattic/day-one-apple/2023-03-28.git.tar",
+            "automattic/day-one-apple/na",
+            "automattic/pocket-casts-ios/2023-03-28.git.tar",
+            "automattic/pocket-casts-ios/nah",
+            "automattic/simplenote-ios/2023-03-28.git.tar"
+        ])
+        XCTAssertEqual(
+            manifest,
+            """
+            automattic/day-one-apple/2023-03-28.git.tar
+            automattic/pocket-casts-ios/2023-03-28.git.tar
+            automattic/simplenote-ios/2023-03-28.git.tar
+            """
+        )
+    }
+
+    func testManifestOnlyContainsTheMostRecentOne() throws {
+        let manifest = try getManifest(withFiles: [
+            "automattic/day-one-apple/2023-03-27.git.tar",
+            "automattic/day-one-apple/2023-03-28.git.tar"
+        ])
+        XCTAssertEqual(manifest, "automattic/day-one-apple/2023-03-28.git.tar")
+    }
+
+    private func getManifest(withFiles files: [String]) throws -> String {
+        let gitMirrorDir = AbsolutePath("/git-mirrors")
+        let fileSystem = InMemoryFileSystem()
+        try files.forEach {
+            let path = gitMirrorDir.appending(RelativePath($0))
+            try fileSystem.createDirectory(path.parentDirectory, recursive: true)
+            try fileSystem.writeFileContents(path, bytes: "")
+            // Also create an empty directory and an empty file to mess with the tests.
+            try fileSystem.createDirectory(path.parentDirectory.appending(component: "dir"), recursive: true)
+            try fileSystem.writeFileContents(path.parentDirectory.appending(component: "empty-file"), bytes: "")
+        }
+        return try gitMirrorsManifest(fileSystem: fileSystem, gitMirrorStorageDirectory: gitMirrorDir.asURL)
+    }
+
+}

--- a/Tests/libhostmgrTests/GitMirrorTests.swift
+++ b/Tests/libhostmgrTests/GitMirrorTests.swift
@@ -43,9 +43,16 @@ class GitMirrorTests: XCTestCase {
     func testManifestOnlyContainsTheMostRecentOne() throws {
         let manifest = try getManifest(withFiles: [
             "automattic/day-one-apple/2023-03-27.git.tar",
-            "automattic/day-one-apple/2023-03-28.git.tar"
+            "automattic/day-one-apple/2023-03-28.git.tar",
+            "automattic/wordpress-ios/2023-03-24.git.tar",
+            "automattic/wordpress-ios/2023-03-26.git.tar"
         ])
-        XCTAssertEqual(manifest, "automattic/day-one-apple/2023-03-28.git.tar")
+        XCTAssertEqual(
+            manifest,
+            """
+            automattic/day-one-apple/2023-03-28.git.tar
+            automattic/wordpress-ios/2023-03-26.git.tar
+            """)
     }
 
     private func getManifest(withFiles files: [String]) throws -> String {


### PR DESCRIPTION
The git mirrors manifest should contain only the most recent caches. I noticed the current implementation relies on FileManager's [subpaths](https://developer.apple.com/documentation/foundation/filemanager/1413742-subpaths) function to return an ordered list where the most recent one comes after the older ones. But the API doc does not explicitly say the returned list is ordered. So I've re-implemented the manifest generation to ensure it contains the most recent ones.