### PR TITLE
Add missing 'var' to the expected vm-images directory

### DIFF
--- a/Tests/libhostmgrTests/Model/PathsTests.swift
+++ b/Tests/libhostmgrTests/Model/PathsTests.swift
@@ -19,8 +19,16 @@ final class PathsTests: XCTestCase {
     }
 
     func testThatVMStoragePathIsCorrect() {
-        validate(path: Paths.vmImageStorageDirectory, resolvesTo: "/usr/local/var/vm-images", forArchitecture: .x64)
-        validate(path: Paths.vmImageStorageDirectory, resolvesTo: "/opt/homebrew/var/vm-images", forArchitecture: .arm64)
+        validate(
+            path: Paths.vmImageStorageDirectory,
+            resolvesTo: "/usr/local/var/vm-images",
+            forArchitecture: .x64
+        )
+        validate(
+            path: Paths.vmImageStorageDirectory,
+            resolvesTo: "/opt/homebrew/var/vm-images",
+            forArchitecture: .arm64
+        )
     }
 
     func testThatGitMirrorStoragePathIsCorrect() {

--- a/Tests/libhostmgrTests/Model/PathsTests.swift
+++ b/Tests/libhostmgrTests/Model/PathsTests.swift
@@ -20,7 +20,7 @@ final class PathsTests: XCTestCase {
 
     func testThatVMStoragePathIsCorrect() {
         validate(path: Paths.vmImageStorageDirectory, resolvesTo: "/usr/local/var/vm-images", forArchitecture: .x64)
-        validate(path: Paths.vmImageStorageDirectory, resolvesTo: "/opt/homebrew/vm-images", forArchitecture: .arm64)
+        validate(path: Paths.vmImageStorageDirectory, resolvesTo: "/opt/homebrew/var/vm-images", forArchitecture: .arm64)
     }
 
     func testThatGitMirrorStoragePathIsCorrect() {

--- a/Tests/libhostmgrTests/Model/PathsTests.swift
+++ b/Tests/libhostmgrTests/Model/PathsTests.swift
@@ -33,8 +33,16 @@ final class PathsTests: XCTestCase {
 
     func testThatGitMirrorStoragePathIsCorrect() {
         let path = Paths.gitMirrorStorageDirectory
-        validate(path: path, resolvesTo: "/usr/local/var/git-mirrors", forArchitecture: .x64)
-        validate(path: path, resolvesTo: "/opt/homebrew/git-mirrors", forArchitecture: .arm64)
+        validate(
+            path: path,
+            resolvesTo: "/usr/local/var/git-mirrors",
+            forArchitecture: .x64
+        )
+        validate(
+            path: path,
+            resolvesTo: "/opt/homebrew/var/git-mirrors",
+            forArchitecture: .arm64
+        )
     }
 
     @available(macOS 13.0, *)


### PR DESCRIPTION
This PR fixes a test failure when running on M1 Mac. The failing test hasn't been caught by CI because the `validate` function only run when running machine is on the expected arch type. To test, run the full test suite on an M1 machine, and the test suite should pass.