### PR TITLE
Add missing 'var' to the expected git-mirrors directory

### DIFF
--- a/Tests/libhostmgrTests/Model/PathsTests.swift
+++ b/Tests/libhostmgrTests/Model/PathsTests.swift
@@ -33,8 +33,16 @@ final class PathsTests: XCTestCase {
 
     func testThatGitMirrorStoragePathIsCorrect() {
         let path = Paths.gitMirrorStorageDirectory
-        validate(path: path, resolvesTo: "/usr/local/var/git-mirrors", forArchitecture: .x64)
-        validate(path: path, resolvesTo: "/opt/homebrew/git-mirrors", forArchitecture: .arm64)
+        validate(
+            path: path,
+            resolvesTo: "/usr/local/var/git-mirrors",
+            forArchitecture: .x64
+        )
+        validate(
+            path: path,
+            resolvesTo: "/opt/homebrew/var/git-mirrors",
+            forArchitecture: .arm64
+        )
     }
 
     @available(macOS 13.0, *)


### PR DESCRIPTION
Completes the work started in #58.

On `trunk`:

![image](https://user-images.githubusercontent.com/1218433/232380334-97a0aa7c-0260-4490-a42c-10d4181e0282.png)

On this branch:

<img width="960" alt="Screenshot 2023-04-17 at 2 49 13 pm" src="https://user-images.githubusercontent.com/1218433/232381122-de75c10c-f7cb-4596-b719-a28487bb214a.png">
