### PR TITLE
Fix Intel Compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,9 @@ lint:
 lintfix:
 	docker run -it --rm -v `pwd`:`pwd` -w `pwd` ghcr.io/realm/swiftlint:0.47.1 swiftlint --autocorrect
 
-build-release:
+build:
 	@echo "--- Building Release"
-	swift build -c release
+	swift build -c release --arch arm64 --arch x86_64
 
 release: build-release
 	@echo "--- Tagging Release"

--- a/Package.resolved
+++ b/Package.resolved
@@ -105,7 +105,7 @@
       "location" : "https://github.com/jkmassel/tinys3.git",
       "state" : {
         "branch" : "main",
-        "revision" : "31b1568aa7ab6354b42cd8b344fbb5bc57c1620c"
+        "revision" : "6569b05ebe5bea0252346dbd9db33718efd531ee"
       }
     }
   ],

--- a/Sources/hostmgr/HostMgrCommand.swift
+++ b/Sources/hostmgr/HostMgrCommand.swift
@@ -5,7 +5,7 @@ import libhostmgr
 @main
 struct Hostmgr: AsyncParsableCommand {
 
-    private static var appVersion = "0.17.1"
+    private static var appVersion = "0.17.2"
 
     static var configuration = CommandConfiguration(
         abstract: "A utility for managing VM hosts",

--- a/Sources/hostmgr/VMCommand.swift
+++ b/Sources/hostmgr/VMCommand.swift
@@ -8,6 +8,7 @@ struct VMCommand: AsyncParsableCommand {
         abstract: "Allows working with VMs",
         subcommands: [
             VMCleanCommand.self,
+            VMDetailsCommand.self,
             VMExistsCommand.self,
             VMFetchCommand.self,
             VMListCommand.self,

--- a/Sources/hostmgr/commands/vm/VMDetails.swift
+++ b/Sources/hostmgr/commands/vm/VMDetails.swift
@@ -22,7 +22,7 @@ struct VMDetailsCommand: ParsableCommand {
         }
 
         guard runningVM.hasIpV4Address else {
-            Console.crash(message: "The VM \(self.virtualMachine) does not have an IP address", reason: .invalidVMStatus)
+            Console.crash(message: "The VM \(runningVM) does not have an IP address", reason: .invalidVMStatus)
         }
 
         print("IPv4 Address:\t\(runningVM.ipAddress)")

--- a/Sources/hostmgr/commands/vm/VMDetails.swift
+++ b/Sources/hostmgr/commands/vm/VMDetails.swift
@@ -1,0 +1,30 @@
+import Foundation
+import ArgumentParser
+import libhostmgr
+
+struct VMDetailsCommand: ParsableCommand {
+
+    static let configuration = CommandConfiguration(
+        commandName: "details",
+        abstract: "Shows information about a given VM"
+    )
+
+    @Argument(help: "The VM to fetch details for")
+    var virtualMachine: String
+
+    func run() throws {
+        guard let virtualMachine = try ParallelsVMRepository().lookupVM(byIdentifier: self.virtualMachine) else {
+            Console.crash(message: "There is no local VM named \(self.virtualMachine)", reason: .fileNotFound)
+        }
+
+        guard let runningVM = virtualMachine.asRunningVM() else {
+            Console.crash(message: "There is no running VM named \(self.virtualMachine)", reason: .invalidVMStatus)
+        }
+
+        guard runningVM.hasIpV4Address else {
+            Console.crash(message: "The VM \(self.virtualMachine) does not have an IP address", reason: .invalidVMStatus)
+        }
+
+        print("IPv4 Address:\t\(runningVM.ipAddress)")
+    }
+}


### PR DESCRIPTION
Re-adds the `vm details` command, which is still required on Intel machines.

Also fixes a small issue with `make`-based builds not producing universal binaries, and adopts a slightly newer version of `tinys3` with improved logging.