### PR TITLE
Run on Xcode 14.3.1

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 # Nodes with values to reuse in the pipeline.
 common_params:
   plugins: &common_plugins
-  - &bash_cache automattic/bash-cache#v1.3.2: ~
+  - &bash_cache automattic/a8c-ci-toolkit#2.18.2
   # Common environment values to use with the `env` key.
   env: &common_env
     IMAGE_ID: xcode-14.3.1

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,7 +4,7 @@ common_params:
   - &bash_cache automattic/bash-cache#v1.3.2: ~
   # Common environment values to use with the `env` key.
   env: &common_env
-    IMAGE_ID: xcode-14.2
+    IMAGE_ID: xcode-14.3.1
 
 # This is the default pipeline – it will build and test the app
 steps:


### PR DESCRIPTION
@jkmassel's #62 seems to fix the recent failures we've seen on the basis that [the CI step that uses the code is green](https://buildkite.com/automattic/hostmgr/builds/380#01899f6d-3982-43ca-be09-2f9de6a2ed02).

However, I noticed that this repo still uses Xcode 14.2 in CI, while the failures I've seen are all on the latest 14.3.1 image. This PR was meant as a simple tooling upgrade, but revealed the same CI failure at the repository level. See [the first build on this branch](https://buildkite.com/automattic/hostmgr/builds/383#0189aa0c-2f63-4afb-bcc2-8b09b9b940a8).

I think my understanding of the infra might be faulty. I assumed that #62 worked because of the new code in this repo, but maybe the code itself needs to be deployed before it can be used the `buildkite-ci`? 🤔 

---

External failures example:

https://buildkite.com/automattic/gutenberg-mobile/builds/6661#0189a9f4-63a9-4384-b02a-56ddc2269e0d

![image](https://github.com/Automattic/hostmgr/assets/1218433/c50a8035-da46-4a98-9b8a-38ec64b6c825)
