### PR TITLE
Revert "Kill VM processes before unregister"

### DIFF
--- a/Sources/libhostmgr/libhostmgr.swift
+++ b/Sources/libhostmgr/libhostmgr.swift
@@ -1,6 +1,5 @@
 import Foundation
 import prlctl
-import ShellOut
 
 /// Downloads and registers an image by name
 ///
@@ -111,8 +110,6 @@ public func resetVMStorage() throws {
         Console.info("Removing temp VM file for \(localVM.filename)")
         try repository.delete(image: localVM)
     }
-
-    killVMProcesses()
 
     try ParallelsVMRepository().lookupVMs().forEach { parallelsVM in
         Console.info("Removing Registered VM \(parallelsVM.name)")
@@ -319,18 +316,4 @@ func applyVMSettings(_ settings: [StoppedVM.VMOption], to parallelsVM: StoppedVM
     } catch {
         Console.warn("Unable to remove device: \(error.localizedDescription)")
     }
-}
-
-/// Force kill all running VM processes
-///
-/// We have a relatively frequent error in CI jobs:
-/// "Failed to unregister the VM: Unable to perform the action because the
-/// virtual machine is busy. The virtual machine is currently running.
-/// Please try again later."
-///
-/// This functions kills all the running VM processes so that we can unregister it later.
-func killVMProcesses() {
-    Console.info("Killing running virtual machines")
-    // The command failure is ignored because there may not be any running VM.
-    _ = try? shellOut(to: "pkill", arguments: ["-9", "-f", #"Parallels VM\.app/Contents/MacOS/prl_vm_app"#])
 }


### PR DESCRIPTION
This reverts commit 0f646d5c9d7f6c4237a48d83e72d727530ac92c0.

The change was added in https://github.com/Automattic/hostmgr/pull/66 and released in 0.17.4 https://github.com/Automattic/hostmgr/pull/67. Unfortunately it didn't work. There were two issues I noticed in 0.17.4.

Please note, before deploying 0.17.4 to CI agents, CI agents runs hostmgr 0.15.13. So there is a big chunk of code in hostmgr is new to CI.

The first issue is, sometimes VM can't be booted. My guess is that might be caused by the changes [between 0.15.13 and 0.17.3](https://github.com/Automattic/hostmgr/compare/0.15.13...0.17.3).

The second issue is, the "killing vm process" change sometimes produces a "Parallels Desktop is shutting down" error (see [this build](https://buildkite.com/automattic/pocket-casts-ios/builds/4662#018add36-d5c9-49c8-b895-b91023c5902b/22-25)). My guess is we may need to wait a bit after the `pkill` command, for Parallels Desktop to completely kill the process.

But anyway, given this change didn't work, we should get rid of it. Maybe we can create a 0.15.14 which is 0.15.13 plus this `pkill` command change. But I'll try test it first before making that change.