### PR TITLE
Only publish git mirror if the archive file is 50 MB or larger

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ A description of this package.
 
 ## Release
 
-1. Create a PR to update the [`appVersion`](Sources/hostmgr/main.swift).
-1. After the PR is merged, create a tag named same as the `appVersion`,
-1. Once the tag is pushed up to this repo, a CI job will be automatically kicked off to create a GitHub release for the tag. Wait for the CI job to finish.
-1. Update [the hostmgr homebrew formula](https://github.com/Automattic/homebrew-build-tools/blob/trunk/hostmgr.rb)'s `url` and `sha256` fields, whose value can be found in the GitHub release created above.
+1. Create a PR to update [the version property](Sources/libhostmgr/libhostmgr.swift).
+1. After the PR is merged, create a tag named same as the updated version,
+1. Once the tag is pushed up to this repo, a CI job will be automatically kicked off to create a GitHub release for the tag.

--- a/Sources/hostmgr/commands/cache/GitMirrorPublishCommand.swift
+++ b/Sources/hostmgr/commands/cache/GitMirrorPublishCommand.swift
@@ -42,7 +42,8 @@ struct GitMirrorPublishCommand: AsyncParsableCommand {
         // to git mirror files. If the file size is too small, git checkout should be pretty fast and it's okay to not
         // save the git repo in S3.
         let archiveSize = try FileManager.default.size(ofObjectAt: gitMirror.archivePath)
-        let archiveSizeInMB = Measurement(value: Double(archiveSize), unit: UnitInformationStorage.bytes).converted(to: .megabytes)
+        let archiveSizeInMB = Measurement(value: Double(archiveSize), unit: UnitInformationStorage.bytes)
+            .converted(to: .megabytes)
         if archiveSizeInMB.value < 50 {
             Console.info("Skipping uploading the git mirror because it is too small")
             return

--- a/Sources/libhostmgr/libhostmgr.swift
+++ b/Sources/libhostmgr/libhostmgr.swift
@@ -1,7 +1,7 @@
 import Foundation
 import OSLog
 
-public let hostmgrVersion = "0.50.0-beta.10"
+public let hostmgrVersion = "0.50.0-beta.11"
 
 public extension Logger {
     private static let subsystem = "com.automattic.hostmgr"


### PR DESCRIPTION
I ran into an error (see [this build](https://buildkite.com/automattic/wordpress-authenticator-ios/builds/954#018bfe59-abd7-4da6-a5e1-5d6d27927936/78-84)) that's caused by the `hostmgr cache publish-git-mirror` command.

> Error: Your proposed upload is smaller than the minimum allowed size

The root cause is S3 has a minimal size requirement for each part in a multipart uploads. In this PR, I added a archive file size check: if it's too small, don't bother upload it to S3 because the git repo should be pretty fast to checkout.