### PR TITLE
Fix incorrect step dependency in buildkite pipline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -67,7 +67,7 @@ steps:
     env: *common_env
     plugins: *common_plugins
     depends_on:
-      - "test-arm64"
+      - "test"
       - "validate-release-build"
     if: build.tag != null
     agents:

--- a/Sources/libhostmgr/libhostmgr.swift
+++ b/Sources/libhostmgr/libhostmgr.swift
@@ -1,7 +1,7 @@
 import Foundation
 import OSLog
 
-public let hostmgrVersion = "0.50.0-beta.11"
+public let hostmgrVersion = "0.50.0-beta.12"
 
 public extension Logger {
     private static let subsystem = "com.automattic.hostmgr"


### PR DESCRIPTION
`0.50.0-beta-11` release failed (see [this build](https://buildkite.com/automattic/hostmgr/builds/495#018c0dfa-7b2e-4dfd-904b-a9619710abdb)) because the "test-arm64" dependency doesn't exist.

I made another version bump in this PR instead of re-creating the `0.50.0-beta.11`, because I want to avoid deleting tags even though the version `0.50.0-beta.11` was never shipped.