### PR TITLE
Fix local images format in the 'vm list' command

### DIFF
--- a/Sources/hostmgr/commands/vm/VMList.swift
+++ b/Sources/hostmgr/commands/vm/VMList.swift
@@ -53,10 +53,9 @@ struct VMListCommand: AsyncParsableCommand {
     private func format(localVM: LocalVMImage) throws -> Console.TableRow {
         return [
             "Local",
-//            localVM.basename,
-//            localVM.state.rawValue,
-//            localVM.architecture.rawValue,
             localVM.name,
+            localVM.state.rawValue,
+            "", // localVM.architecture.rawValue,
             Format.fileBytes(try localVM.fileSize)
         ]
     }

--- a/Sources/libhostmgr/Platforms/LocalVMImage.swift
+++ b/Sources/libhostmgr/Platforms/LocalVMImage.swift
@@ -52,7 +52,7 @@ public struct LocalVMImage: Equatable {
     }
 }
 
-public enum VMImageState {
-    case packaged
-    case ready
+public enum VMImageState: String {
+    case packaged = "Packaged"
+    case ready = "Ready"
 }


### PR DESCRIPTION
Here is an example of the local image output:

```
$ hostmgr vm list
Location  Filename           State     Architecture  Size
Local     macos-13.5.2       16.26 GB
Local     macos-13.5.2       13.42 GB
Remote    macos-13.5.2       Packaged                13.42 GB
Remote    xcode-15.0.1       Packaged                46.34 GB
Remote    xcode-15.1.beta.1  Packaged                46.95 GB
Remote    xcode-15.1.beta.2  Packaged                47.05 GB
```

With this PR, the output looks like this:

```
swift run --skip-build hostmgr vm list
Location  Filename           State     Architecture  Size
Local     macos-13.5.2       Ready                   16.26 GB
Local     macos-13.5.2       Packaged                13.42 GB
Remote    macos-13.5.2       Packaged                13.42 GB
Remote    xcode-15.0.1       Packaged                46.34 GB
Remote    xcode-15.1.beta.1  Packaged                46.95 GB
Remote    xcode-15.1.beta.2  Packaged                47.05 GB
```