### PR TITLE
Release 0.50.0

### DIFF
--- a/Sources/libhostmgr/libhostmgr.swift
+++ b/Sources/libhostmgr/libhostmgr.swift
@@ -1,7 +1,7 @@
 import Foundation
 import OSLog
 
-public let hostmgrVersion = "0.50.0-beta.12"
+public let hostmgrVersion = "0.50.0"
 
 public extension Logger {
     private static let subsystem = "com.automattic.hostmgr"


### PR DESCRIPTION
Preparing a new release so we can deploy it to our hosts—especially to start allowing them to run jobs on Xcode-15.3 VM.

> **Note**
> I decided to go outside the `-beta` version scheme (and GitHub Pre-Releases) and do an official `0.50.0` one (and the future GitHub Release that I'll create once this lands won't be a Pre-Release).
>
> Even if we are not done cleaning up the source code for all old references to Parallels and Intel, this is still a `<1.0` version code so we're still free to break the API and remove stuff in future versions, and in the meantime this version is working perfectly well on our ARM infra, so I figured it shouldn't really be `beta` anymore.