### PR TITLE
Small output improvements to `vm list`

### DIFF
--- a/Sources/hostmgr/commands/vm/VMList.swift
+++ b/Sources/hostmgr/commands/vm/VMList.swift
@@ -47,7 +47,7 @@ struct VMListCommand: AsyncParsableCommand {
         Console.printTable(
             data: data,
             columnTitles: ["Location", "Filename", "State", "Size"],
-            columnsAlignments: [.left, .left, .left, .right]
+            columnAlignments: [.left, .left, .left, .right]
         )
     }
 

--- a/Sources/hostmgr/commands/vm/VMList.swift
+++ b/Sources/hostmgr/commands/vm/VMList.swift
@@ -46,8 +46,8 @@ struct VMListCommand: AsyncParsableCommand {
 
         Console.printTable(
             data: data,
-            columnTitles: ["Location", "Filename", "State", "Allocated Size", "Total Size"],
-            columnsAlignments: [.left, .left, .left, .right, .right]
+            columnTitles: ["Location", "Filename", "State", "Size"],
+            columnsAlignments: [.left, .left, .left, .right]
         )
     }
 
@@ -56,7 +56,6 @@ struct VMListCommand: AsyncParsableCommand {
             "💻 Local",
             localVM.name,
             localVM.state.rawValue,
-            Format.fileBytes(try localVM.allocatedFileSize),
             Format.fileBytes(try localVM.fileSize)
         ]
     }
@@ -66,7 +65,6 @@ struct VMListCommand: AsyncParsableCommand {
             "🌐 Remote",
             remoteVM.name,
             VMImageState.packaged.rawValue,
-            "-",
             Format.fileBytes(remoteVM.size)
         ]
     }

--- a/Sources/hostmgr/commands/vm/VMList.swift
+++ b/Sources/hostmgr/commands/vm/VMList.swift
@@ -46,7 +46,7 @@ struct VMListCommand: AsyncParsableCommand {
 
         Console.printTable(
             data: data,
-            columnTitles: ["Location", "Filename", "State", "Architecture", "Size"]
+            columnTitles: ["Location", "Filename", "State", "Size"]
         )
     }
 
@@ -55,7 +55,6 @@ struct VMListCommand: AsyncParsableCommand {
             "Local",
             localVM.name,
             localVM.state.rawValue,
-            "", // localVM.architecture.rawValue,
             Format.fileBytes(try localVM.fileSize)
         ]
     }
@@ -65,7 +64,6 @@ struct VMListCommand: AsyncParsableCommand {
             "Remote",
             remoteVM.name,
             "Packaged",
-            "",
             Format.fileBytes(remoteVM.size)
         ]
     }

--- a/Sources/hostmgr/commands/vm/VMList.swift
+++ b/Sources/hostmgr/commands/vm/VMList.swift
@@ -37,7 +37,7 @@ struct VMListCommand: AsyncParsableCommand {
         var data = Console.Table()
 
         if self.location.includesLocal {
-            data.append(contentsOf: try await vmManager.list(sortedBy: .name).map(self.format))
+            data.append(contentsOf: try await vmManager.list(sortedBy: .state).map(self.format))
         }
 
         if self.location.includesRemote {

--- a/Sources/hostmgr/commands/vm/VMList.swift
+++ b/Sources/hostmgr/commands/vm/VMList.swift
@@ -52,7 +52,7 @@ struct VMListCommand: AsyncParsableCommand {
 
     private func format(localVM: LocalVMImage) throws -> Console.TableRow {
         return [
-            "Local",
+            "💻 Local",
             localVM.name,
             localVM.state.rawValue,
             Format.fileBytes(try localVM.fileSize)
@@ -61,9 +61,9 @@ struct VMListCommand: AsyncParsableCommand {
 
     private func format(remoteVM: RemoteVMImage) throws -> Console.TableRow {
         return [
-            "Remote",
+            "🌐 Remote",
             remoteVM.name,
-            "Packaged",
+            VMImageState.packaged.rawValue,
             Format.fileBytes(remoteVM.size)
         ]
     }

--- a/Sources/hostmgr/commands/vm/VMList.swift
+++ b/Sources/hostmgr/commands/vm/VMList.swift
@@ -46,7 +46,8 @@ struct VMListCommand: AsyncParsableCommand {
 
         Console.printTable(
             data: data,
-            columnTitles: ["Location", "Filename", "State", "Size"]
+            columnTitles: ["Location", "Filename", "State", "Allocated Size", "Total Size"],
+            columnsAlignments: [.left, .left, .left, .right, .right]
         )
     }
 
@@ -55,6 +56,7 @@ struct VMListCommand: AsyncParsableCommand {
             "💻 Local",
             localVM.name,
             localVM.state.rawValue,
+            Format.fileBytes(try localVM.allocatedFileSize),
             Format.fileBytes(try localVM.fileSize)
         ]
     }
@@ -64,6 +66,7 @@ struct VMListCommand: AsyncParsableCommand {
             "🌐 Remote",
             remoteVM.name,
             VMImageState.packaged.rawValue,
+            "-",
             Format.fileBytes(remoteVM.size)
         ]
     }

--- a/Sources/hostmgr/commands/vm/VMStart.swift
+++ b/Sources/hostmgr/commands/vm/VMStart.swift
@@ -58,13 +58,12 @@ struct VMStartCommand: AsyncParsableCommand {
                 return
             }
 
-            let ipAddress: IPv4Address
-            if waitForever {
-                let timeout = Duration.seconds(1_000_000_000) // Doesn't crash like .greatestFiniteMagnitude
-                ipAddress = try await vmManager.waitForVMStartup(for: configuration, timeout: timeout)
+            let timeout: Duration = if waitForever {
+                .seconds(1_000_000_000) // Doesn't crash like .greatestFiniteMagnitude
             } else {
-                ipAddress = try await vmManager.waitForVMStartup(for: configuration, timeout: .seconds(30))
+                .seconds(30)
             }
+            let ipAddress = try await vmManager.waitForVMStartup(for: configuration, timeout: timeout)
 
             Console.success("Booted \(name) in \(Format.elapsedTime(between: startTime, and: .now))")
             Console.success("VM SSH IP Address: \(ipAddress)")

--- a/Sources/hostmgr/commands/vm/VMStart.swift
+++ b/Sources/hostmgr/commands/vm/VMStart.swift
@@ -50,6 +50,7 @@ struct VMStartCommand: AsyncParsableCommand {
                 waitForNetworking: !skipNetworkChecks
             )
 
+            Console.success("Starting VM with handle: \(self.handle)")
             try await vmManager.startVM(configuration: configuration)
 
             if skipNetworkChecks {
@@ -66,8 +67,7 @@ struct VMStartCommand: AsyncParsableCommand {
             }
 
             Console.success("Booted \(name) in \(Format.elapsedTime(between: startTime, and: .now))")
-            Console.success("- VM Handle: \(self.handle)")
-            Console.success("- VM IP Address: \(ipAddress)")
+            Console.success("VM SSH IP Address: \(ipAddress)")
         } catch let error as HostmgrError {
             Console.crash(error)
         }

--- a/Sources/hostmgr/commands/vm/VMStart.swift
+++ b/Sources/hostmgr/commands/vm/VMStart.swift
@@ -1,6 +1,7 @@
 import Foundation
 import ArgumentParser
 import libhostmgr
+import Network
 
 struct VMStartCommand: AsyncParsableCommand {
 
@@ -56,15 +57,17 @@ struct VMStartCommand: AsyncParsableCommand {
                 return
             }
 
+            let ipAddress: IPv4Address
             if waitForever {
                 let timeout = Duration.seconds(1_000_000_000) // Doesn't crash like .greatestFiniteMagnitude
-                try await vmManager.waitForVMStartup(for: configuration, timeout: timeout)
+                ipAddress = try await vmManager.waitForVMStartup(for: configuration, timeout: timeout)
             } else {
-                try await vmManager.waitForVMStartup(for: configuration, timeout: .seconds(30))
+                ipAddress = try await vmManager.waitForVMStartup(for: configuration, timeout: .seconds(30))
             }
 
             Console.success("Booted \(name) in \(Format.elapsedTime(between: startTime, and: .now))")
-            Console.success("VM Handle: \(self.handle)")
+            Console.success("- VM Handle: \(self.handle)")
+            Console.success("- VM IP Address: \(ipAddress)")
         } catch let error as HostmgrError {
             Console.crash(error)
         }

--- a/Sources/hostmgr/commands/vm/VMStart.swift
+++ b/Sources/hostmgr/commands/vm/VMStart.swift
@@ -64,6 +64,7 @@ struct VMStartCommand: AsyncParsableCommand {
             }
 
             Console.success("Booted \(name) in \(Format.elapsedTime(between: startTime, and: .now))")
+            Console.success("VM Handle: \(self.handle)")
         } catch let error as HostmgrError {
             Console.crash(error)
         }

--- a/Sources/libhostmgr/CLI/Console.swift
+++ b/Sources/libhostmgr/CLI/Console.swift
@@ -103,7 +103,7 @@ public struct Console: Consolable {
         for row in table {
             let string = zip(row, columnCount.indices).map { text, colIdx in
                 let colWidth = columnCount[colIdx]
-                let alignment: TableColumnAlignment = columnAlignments.indices ~= colIdx ? columnAlignments[colIdx] : .left
+                let alignment = columnAlignments.indices ~= colIdx ? columnAlignments[colIdx] : .left
                 return self.padString(text, toLength: colWidth, align: alignment)
             }.joined(separator: columnSeparator)
             self.terminal.print(string)
@@ -316,8 +316,16 @@ extension Console {
         return Console().printList(list, title: title)
     }
 
-    @discardableResult public static func printTable(data: TableConvertable, columnTitles: [String] = [], columnAlignments: [TableColumnAlignment] = []) -> Self {
-        return Console().printTable(data: data.asTable(), columnTitles: columnTitles, columnAlignments: columnAlignments)
+    @discardableResult public static func printTable(
+        data: TableConvertable,
+        columnTitles: [String] = [],
+        columnAlignments: [TableColumnAlignment] = []
+    ) -> Self {
+        return Console().printTable(
+            data: data.asTable(),
+            columnTitles: columnTitles,
+            columnAlignments: columnAlignments
+        )
     }
 
     public static func crash(_ error: HostmgrError) -> Never {

--- a/Sources/libhostmgr/CLI/Console.swift
+++ b/Sources/libhostmgr/CLI/Console.swift
@@ -82,7 +82,7 @@ public struct Console: Consolable {
         columnTitles: [String] = [],
         titleRowSeparator: Character? = "-",
         columnSeparator: String = " | ",
-        columnsAlignments: [TableColumnAlignment] = []
+        columnAlignments: [TableColumnAlignment] = []
     ) -> Self {
 
         if data.isEmpty {
@@ -103,7 +103,7 @@ public struct Console: Consolable {
         for row in table {
             let string = zip(row, columnCount.indices).map { text, colIdx in
                 let colWidth = columnCount[colIdx]
-                let alignment: TableColumnAlignment = columnsAlignments.indices ~= colIdx ? columnsAlignments[colIdx] : .left
+                let alignment: TableColumnAlignment = columnAlignments.indices ~= colIdx ? columnAlignments[colIdx] : .left
                 return self.padString(text, toLength: colWidth, align: alignment)
             }.joined(separator: columnSeparator)
             self.terminal.print(string)
@@ -316,8 +316,8 @@ extension Console {
         return Console().printList(list, title: title)
     }
 
-    @discardableResult public static func printTable(data: TableConvertable, columnTitles: [String] = [], columnsAlignments: [TableColumnAlignment] = []) -> Self {
-        return Console().printTable(data: data.asTable(), columnTitles: columnTitles, columnsAlignments: columnsAlignments)
+    @discardableResult public static func printTable(data: TableConvertable, columnTitles: [String] = [], columnAlignments: [TableColumnAlignment] = []) -> Self {
+        return Console().printTable(data: data.asTable(), columnTitles: columnTitles, columnAlignments: columnAlignments)
     }
 
     public static func crash(_ error: HostmgrError) -> Never {

--- a/Sources/libhostmgr/CLI/Console.swift
+++ b/Sources/libhostmgr/CLI/Console.swift
@@ -80,7 +80,8 @@ public struct Console: Consolable {
     @discardableResult public func printTable(
         data: Table,
         columnTitles: [String] = [],
-        columnSeparator: String = "  "
+        titleRowSeparator: Character? = "-",
+        columnSeparator: String = " | "
     ) -> Self {
 
         if data.isEmpty {
@@ -89,9 +90,14 @@ public struct Console: Consolable {
         }
 
         // Prepend the Column Titles, if present
-        let table = columnTitles.isEmpty ? data : [columnTitles] + data
+        var table = columnTitles.isEmpty ? data : [columnTitles] + data
 
         let columnCount = columnCounts(for: table)
+
+        if let titleRowSeparator {
+            let headerSeparatorRow = columnCount.map { String(repeating: titleRowSeparator, count: $0) }
+            table.insert(headerSeparatorRow, at: 1)
+        }
 
         for row in table {
             let string = zip(row, columnCount).map(self.padString).joined(separator: columnSeparator)
@@ -330,7 +336,7 @@ extension Console {
     public typealias Table = [TableRow]
 
     func columnCounts(for table: Table) -> [Int] {
-        transpose(matrix: table).map { $0.map(\.count).max() ?? 0 }
+        transpose(matrix: table).map { $0.map(\.monospaceWidth).max() ?? 0 }
     }
 
     func transpose(matrix: Table) -> Table {

--- a/Sources/libhostmgr/CLI/Console.swift
+++ b/Sources/libhostmgr/CLI/Console.swift
@@ -95,7 +95,7 @@ public struct Console: Consolable {
 
         let columnCount = columnCounts(for: table)
 
-        if let titleRowSeparator {
+        if !columnTitles.isEmpty, let titleRowSeparator {
             let headerSeparatorRow = columnCount.map { String(repeating: titleRowSeparator, count: $0) }
             table.insert(headerSeparatorRow, at: 1)
         }

--- a/Sources/libhostmgr/Extensions/FileManager.swift
+++ b/Sources/libhostmgr/Extensions/FileManager.swift
@@ -36,19 +36,16 @@ extension FileManager {
         return values.volumeAvailableCapacityForImportantUsage ?? 0
     }
 
-    public func size(ofObjectAt url: URL, useAllocatedSize: Bool = false) throws -> Int {
+    public func size(ofObjectAt url: URL) throws -> Int {
         if try directoryExists(at: url) {
-            return try directorySize(of: url, useAllocatedSize: useAllocatedSize)
+            return try directorySize(of: url)
         } else {
-            return try fileSize(of: url, useAllocatedSize: useAllocatedSize)
+            return try fileSize(of: url)
         }
     }
 
-    func fileSize(of url: URL, useAllocatedSize: Bool) throws -> Int {
-        let key: URLResourceKey = useAllocatedSize ? .totalFileAllocatedSizeKey : .totalFileSizeKey
-        let property: KeyPath<URLResourceValues, Int?> = useAllocatedSize ? \.totalFileAllocatedSize : \.totalFileSize
-
-        guard let size = try url.resourceValues(forKeys: [key])[keyPath: property] else {
+    func fileSize(of url: URL) throws -> Int {
+        guard let size = try url.resourceValues(forKeys: [.totalFileSizeKey]).totalFileSize else {
             throw CocoaError(.fileReadUnknown)
         }
 
@@ -56,19 +53,16 @@ extension FileManager {
     }
 
     /// returns total allocated size of a the directory including its subFolders or not
-    func directorySize(of url: URL, useAllocatedSize: Bool) throws -> Int {
-        let key: URLResourceKey = useAllocatedSize ? .totalFileAllocatedSizeKey : .totalFileSizeKey
-        let property: KeyPath<URLResourceValues, Int?> = useAllocatedSize ? \.totalFileAllocatedSize : \.totalFileSize
-
+    func directorySize(of url: URL) throws -> Int {
         guard
-            let enumerator = enumerator(at: url, includingPropertiesForKeys: [key]),
+            let enumerator = enumerator(at: url, includingPropertiesForKeys: [.totalFileSizeKey]),
             let urls = enumerator.allObjects as? [URL]
         else {
             return 0
         }
 
         let sizes = try urls
-            .compactMap { try $0.resourceValues(forKeys: [key])[keyPath: property] }
+            .compactMap { try $0.resourceValues(forKeys: [.totalFileSizeKey]).totalFileSize }
 
         return sizes.reduce(0, +)
      }

--- a/Sources/libhostmgr/Extensions/String.swift
+++ b/Sources/libhostmgr/Extensions/String.swift
@@ -1,9 +1,14 @@
 import Foundation
 
 extension String {
-
     public var trimmingWhitespace: String {
         trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    // In a Terminal, emoji characters take near to twice the width as regular characters
+    // This thus accounts for that difference, to reflect the number of Terminal columns this string will span
+    public var monospaceWidth: Int {
+        self.count + self.unicodeScalars.filter(\.properties.isEmojiPresentation).count
     }
 }
 

--- a/Sources/libhostmgr/Foundation+Extensions.swift
+++ b/Sources/libhostmgr/Foundation+Extensions.swift
@@ -9,7 +9,6 @@ public enum ProcessorArchitecture: String {
 }
 
 extension ProcessInfo {
-
     /// How many cores are in this machine?
     ///
     /// On Apple Silicon, this returns the number of Performance Cores + Efficiency Cores
@@ -40,7 +39,6 @@ extension Sequence {
 }
 
 extension String {
-
     public func slugify() -> String {
         self.components(separatedBy: .alphanumerics.inverted).joined(separator: "-")
     }

--- a/Sources/libhostmgr/Model/LocalVMImageSortingStrategy.swift
+++ b/Sources/libhostmgr/Model/LocalVMImageSortingStrategy.swift
@@ -1,21 +1,48 @@
 import Foundation
 
 public enum LocalVMImageSortingStrategy {
-    case name
-    case size
+    case name  // Sort by Name first, then by State
+    case size  // Sort by Size
+    case state // Sort by State first, then by Name
 
     var sortMethod: (LocalVMImage, LocalVMImage) throws -> Bool {
         switch self {
         case .name: return sortByName
         case .size: return sortBySize
+        case .state: return sortByState
         }
     }
 
+    // Sort by Name first, then by State if same Name
     func sortByName(_ lhs: LocalVMImage, _ rhs: LocalVMImage) -> Bool {
-        lhs.name.compare(rhs.name, options: [.diacriticInsensitive, .caseInsensitive]) == .orderedAscending
+        switch nameCompare(lhs, rhs) {
+        case .orderedDescending: false
+        case .orderedSame: stateCompare(lhs, rhs) == .orderedAscending
+        case .orderedAscending: true
+        }
     }
 
     func sortBySize(_ lhs: LocalVMImage, _ rhs: LocalVMImage) throws -> Bool {
         try lhs.fileSize < rhs.fileSize
     }
+
+    // Sort by State first, then by Name if same State
+    func sortByState(_ lhs: LocalVMImage, _ rhs: LocalVMImage) -> Bool {
+        switch stateCompare(lhs, rhs) {
+        case .orderedDescending: false
+        case .orderedSame: nameCompare(lhs, rhs) == .orderedAscending
+        case .orderedAscending: true
+        }
+    }
+
+    private func nameCompare(_ lhs: LocalVMImage, _ rhs: LocalVMImage) -> ComparisonResult {
+        lhs.name.compare(rhs.name, options: [.diacriticInsensitive, .caseInsensitive])
+    }
+
+    private func stateCompare(_ lhs: LocalVMImage, _ rhs: LocalVMImage) -> ComparisonResult {
+        let lhsOrder = VMImageState.allCases.firstIndex(of: lhs.state) ?? 0
+        let rhsOrder = VMImageState.allCases.firstIndex(of: rhs.state) ?? 0
+        return lhsOrder < rhsOrder ? .orderedDescending : lhsOrder == rhsOrder ? .orderedSame : .orderedAscending
+    }
+
 }

--- a/Sources/libhostmgr/Platforms/LocalVMImage.swift
+++ b/Sources/libhostmgr/Platforms/LocalVMImage.swift
@@ -18,6 +18,10 @@ public struct LocalVMImage: Equatable {
     }
 
     public var state: VMImageState {
+        if self.path.pathComponents.starts(with: Paths.vmWorkingStorageDirectory.pathComponents) {
+            return .running
+        }
+
         if path.path.hasSuffix(".vmtemplate") {
             return .ready
         }
@@ -52,7 +56,8 @@ public struct LocalVMImage: Equatable {
     }
 }
 
-public enum VMImageState: String {
-    case packaged = "Packaged"
-    case ready = "Ready"
+public enum VMImageState: String, CaseIterable {
+    case packaged = "📦 Packaged"
+    case ready = "💾 Ready"
+    case running = "▶️ Running"
 }

--- a/Sources/libhostmgr/Platforms/LocalVMImage.swift
+++ b/Sources/libhostmgr/Platforms/LocalVMImage.swift
@@ -59,5 +59,5 @@ public struct LocalVMImage: Equatable {
 public enum VMImageState: String, CaseIterable {
     case packaged = "📦 Packaged"
     case ready = "💾 Ready"
-    case running = "▶️ Running"
+    case running = "🟢 Running"
 }

--- a/Sources/libhostmgr/Platforms/LocalVMImage.swift
+++ b/Sources/libhostmgr/Platforms/LocalVMImage.swift
@@ -51,13 +51,7 @@ public struct LocalVMImage: Equatable {
 
     public var fileSize: Int {
         get throws {
-            try FileManager.default.size(ofObjectAt: path, useAllocatedSize: false)
-        }
-    }
-
-    public var allocatedFileSize: Int {
-        get throws {
-            try FileManager.default.size(ofObjectAt: path, useAllocatedSize: true)
+            try FileManager.default.size(ofObjectAt: path)
         }
     }
 }

--- a/Sources/libhostmgr/Platforms/LocalVMImage.swift
+++ b/Sources/libhostmgr/Platforms/LocalVMImage.swift
@@ -51,7 +51,13 @@ public struct LocalVMImage: Equatable {
 
     public var fileSize: Int {
         get throws {
-            try FileManager.default.size(ofObjectAt: path)
+            try FileManager.default.size(ofObjectAt: path, useAllocatedSize: false)
+        }
+    }
+
+    public var allocatedFileSize: Int {
+        get throws {
+            try FileManager.default.size(ofObjectAt: path, useAllocatedSize: true)
         }
     }
 }

--- a/Sources/libhostmgr/Platforms/VMManager.swift
+++ b/Sources/libhostmgr/Platforms/VMManager.swift
@@ -108,9 +108,10 @@ public struct VMManager {
     public func waitForVMStartup(
         for launchConfiguration: LaunchConfiguration,
         timeout: Duration = .seconds(30)
-    ) async throws {
+    ) async throws -> IPv4Address {
         let address = try await ipAddress(forVmWithName: launchConfiguration.handle)
         try await waitForSSHServer(forAddress: address, timeout: timeout)
+        return address
     }
 
     /// Get details about a VM


### PR DESCRIPTION
Very small improvements… but that will make our life easier when running some `hostmgr vm` commands locally

### `hostmgr vm start`

 - Print the `handle` and `IPv4Address` of the VM after it started

_(useful particularly when we don't provide an explicit `--handle` to `vm start` and wouldn't otherwise easily know which newly-created handle to subsequently run `vm details` on)_

### `hostmgr vm list`

- Remove unused `Architecture` column in `vm list` output
- Add `.running` VMState (corresponding to images located in `working-vm-images`)
- Add emojis for values in `Location` and `State` columns, to make the values more visually distinguishable
- Improve `Console.printTable` to support emojis + add column & header separators—making it more readable
- Make `vm list` now sort VMs by state first, then name

---

The result of `hostmgr vm list` now looks like this in a Terminal:

<img width="562" alt="image" src="https://github.com/Automattic/hostmgr/assets/216089/4449d118-0ab4-4b21-9fa4-7a05c6359484">
