### PR TITLE
Support resuming of aborted uploads during `vm publish`

### DIFF
--- a/Sources/hostmgr/commands/vm/VMPublish.swift
+++ b/Sources/hostmgr/commands/vm/VMPublish.swift
@@ -11,18 +11,22 @@ struct VMPublishCommand: AsyncParsableCommand {
 
     enum CodingKeys: CodingKey {
         case name
+        case noResume
     }
 
     @Argument(
         help: "The name of the image you would like to publish"
     )
     var name: String
+  
+    @Flag(help: "Do not attempt to resume previous uncompleted uploads")
+    var noResume = false
 
     let vmLibrary = RemoteVMLibrary()
 
     func run() async throws {
         let progress = try Console.startImageUpload(Paths.toVMTemplate(named: name))
-        try await vmLibrary.publish(vmNamed: name, progressCallback: progress.update)
+        try await vmLibrary.publish(vmNamed: name, allowResume: !noResume, progressCallback: progress.update)
         progress.succeed()
     }
 }

--- a/Sources/hostmgr/commands/vm/VMPublish.swift
+++ b/Sources/hostmgr/commands/vm/VMPublish.swift
@@ -18,7 +18,7 @@ struct VMPublishCommand: AsyncParsableCommand {
         help: "The name of the image you would like to publish"
     )
     var name: String
-  
+
     @Flag(help: "Do not attempt to resume previous uncompleted uploads")
     var noResume = false
 

--- a/Sources/hostmgr/commands/vm/VMPublish.swift
+++ b/Sources/hostmgr/commands/vm/VMPublish.swift
@@ -25,7 +25,7 @@ struct VMPublishCommand: AsyncParsableCommand {
     let vmLibrary = RemoteVMLibrary()
 
     func run() async throws {
-        let progress = try Console.startImageUpload(Paths.toVMTemplate(named: name))
+        let progress = try Console.startImageUpload(Paths.toArchivedVM(named: name))
         try await vmLibrary.publish(vmNamed: name, allowResume: !noResume, progressCallback: progress.update)
         progress.succeed()
     }

--- a/Sources/libhostmgr/Platforms/RemoteVMLibrary.swift
+++ b/Sources/libhostmgr/Platforms/RemoteVMLibrary.swift
@@ -94,7 +94,7 @@ public struct RemoteVMLibrary {
     public func publish(vmNamed name: String, progressCallback: @escaping ProgressCallback) async throws {
         try await S3Server.vmImages.uploadFile(
             at: Paths.toArchivedVM(named: name),
-            to: "/images/" + Paths.toArchivedVM(named: name).lastPathComponent,
+            to: "images/" + Paths.toArchivedVM(named: name).lastPathComponent,
             progress: progressCallback
         )
     }

--- a/Sources/libhostmgr/Platforms/RemoteVMLibrary.swift
+++ b/Sources/libhostmgr/Platforms/RemoteVMLibrary.swift
@@ -91,7 +91,11 @@ public struct RemoteVMLibrary {
     /// Make a local image available for others to use (by publishing it to S3)
     ///
     /// This method is the preferred way to deploy a VM image
-    public func publish(vmNamed name: String, allowResume: Bool, progressCallback: @escaping ProgressCallback) async throws {
+    public func publish(
+        vmNamed name: String,
+        allowResume: Bool,
+        progressCallback: @escaping ProgressCallback
+    ) async throws {
         try await S3Server.vmImages.uploadFile(
             at: Paths.toArchivedVM(named: name),
             to: "images/" + Paths.toArchivedVM(named: name).lastPathComponent,

--- a/Sources/libhostmgr/Platforms/RemoteVMLibrary.swift
+++ b/Sources/libhostmgr/Platforms/RemoteVMLibrary.swift
@@ -91,10 +91,11 @@ public struct RemoteVMLibrary {
     /// Make a local image available for others to use (by publishing it to S3)
     ///
     /// This method is the preferred way to deploy a VM image
-    public func publish(vmNamed name: String, progressCallback: @escaping ProgressCallback) async throws {
+    public func publish(vmNamed name: String, allowResume: Bool, progressCallback: @escaping ProgressCallback) async throws {
         try await S3Server.vmImages.uploadFile(
             at: Paths.toArchivedVM(named: name),
             to: "images/" + Paths.toArchivedVM(named: name).lastPathComponent,
+            allowResume: allowResume,
             progress: progressCallback
         )
     }

--- a/Sources/libhostmgr/Servers/RemoteFileProvider.swift
+++ b/Sources/libhostmgr/Servers/RemoteFileProvider.swift
@@ -9,7 +9,7 @@ public protocol ReadableRemoteFileProvider: RemoteFileProvider {
 }
 
 protocol WritableRemoteFileProvider: RemoteFileProvider {
-    func uploadFile(at source: URL, to destination: String, progress: @escaping ProgressCallback) async throws
+    func uploadFile(at source: URL, to destination: String, allowResume: Bool, progress: @escaping ProgressCallback) async throws
 }
 
 public extension [ReadableRemoteFileProvider] {

--- a/Sources/libhostmgr/Servers/RemoteFileProvider.swift
+++ b/Sources/libhostmgr/Servers/RemoteFileProvider.swift
@@ -9,7 +9,12 @@ public protocol ReadableRemoteFileProvider: RemoteFileProvider {
 }
 
 protocol WritableRemoteFileProvider: RemoteFileProvider {
-    func uploadFile(at source: URL, to destination: String, allowResume: Bool, progress: @escaping ProgressCallback) async throws
+    func uploadFile(
+        at source: URL,
+        to destination: String,
+        allowResume: Bool,
+        progress: @escaping ProgressCallback
+    ) async throws
 }
 
 public extension [ReadableRemoteFileProvider] {

--- a/Sources/libhostmgr/Servers/S3Server.swift
+++ b/Sources/libhostmgr/Servers/S3Server.swift
@@ -79,11 +79,12 @@ extension S3Server: ReadableRemoteFileProvider {
 
 extension S3Server: WritableRemoteFileProvider {
 
-    public func uploadFile(at source: URL, to destination: String, progress: @escaping ProgressCallback) async throws {
+    public func uploadFile(at source: URL, to destination: String, allowResume: Bool = true, progress: @escaping ProgressCallback) async throws {
         try await s3Client.upload(
             objectAtPath: source,
             toBucket: self.bucketName,
             key: destination,
+            allowResume: allowResume,
             progressCallback: progress
         )
     }

--- a/Sources/libhostmgr/Servers/S3Server.swift
+++ b/Sources/libhostmgr/Servers/S3Server.swift
@@ -79,7 +79,12 @@ extension S3Server: ReadableRemoteFileProvider {
 
 extension S3Server: WritableRemoteFileProvider {
 
-    public func uploadFile(at source: URL, to destination: String, allowResume: Bool = true, progress: @escaping ProgressCallback) async throws {
+    public func uploadFile(
+        at source: URL,
+        to destination: String,
+        allowResume: Bool = true,
+        progress: @escaping ProgressCallback
+    ) async throws {
         try await s3Client.upload(
             objectAtPath: source,
             toBucket: self.bucketName,

--- a/Sources/tinys3/AWSRequest.swift
+++ b/Sources/tinys3/AWSRequest.swift
@@ -109,6 +109,37 @@ struct AWSRequest {
             endpoint: endpoint
         )
     }
+  
+    static func listMultipartUploadsRequest(
+        bucket: String,
+        key: String,
+        credentials: AWSCredentials
+    ) -> AWSRequest {
+        AWSRequest(
+            verb: .get,
+            bucket: bucket,
+            query: [
+                URLQueryItem(name: "uploads", value: nil),
+                URLQueryItem(name: "prefix", value: String(key.trimmingPrefix("/"))),
+            ],
+            credentials: credentials
+        )
+    }
+    
+    static func listPartsRequest(
+        bucket: String,
+        key: String,
+        uploadId: String,
+        credentials: AWSCredentials
+    ) -> AWSRequest {
+        AWSRequest(
+            verb: .get,
+            bucket: bucket,
+            path: key,
+            query: [URLQueryItem(name: "uploadId", value: uploadId)],
+            credentials: credentials
+        )
+    }
 
     static func createMultipartUploadRequest(
         bucket: String,
@@ -185,7 +216,9 @@ extension AWSRequest {
     }
 
     var canonicalQueryString: String {
-        queryItems.asEscapedQueryString
+        queryItems
+            .sorted { $0.name < $1.name }
+            .asEscapedQueryString
     }
 
     var canonicalHeaders: HttpHeaders {

--- a/Sources/tinys3/AWSRequest.swift
+++ b/Sources/tinys3/AWSRequest.swift
@@ -173,7 +173,7 @@ extension AWSRequest {
             URLQueryItem(name: "prefix", value: prefix)
         ], credentials: credentials)
     }
-    
+
     static func headRequest(
         bucket: String,
         key: String,
@@ -205,7 +205,7 @@ extension AWSRequest {
             endpoint: endpoint
         )
     }
-  
+
     static func listMultipartUploadsRequest(
         bucket: String,
         key: String,
@@ -216,12 +216,12 @@ extension AWSRequest {
             bucket: bucket,
             query: [
                 URLQueryItem(name: "uploads", value: nil),
-                URLQueryItem(name: "prefix", value: String(key.trimmingPrefix("/"))),
+                URLQueryItem(name: "prefix", value: String(key.trimmingPrefix("/")))
             ],
             credentials: credentials
         )
     }
-    
+
     static func listPartsRequest(
         bucket: String,
         key: String,

--- a/Sources/tinys3/Helpers.swift
+++ b/Sources/tinys3/Helpers.swift
@@ -46,6 +46,12 @@ func sha256Hash(string: String) -> String {
     sha256Hash(data: Data(string.utf8))
 }
 
+func md5Hash(data: Data) -> String {
+    var hasher = Insecure.MD5()
+    hasher.update(data: data)
+    return hasher.finalize().lowercaseHexValue
+}
+
 func formattedTimestamp(from date: Date = Date()) -> String {
     let formatter = DateFormatter()
     formatter.timeZone = TimeZone(abbreviation: "UTC")

--- a/Sources/tinys3/S3Client.swift
+++ b/Sources/tinys3/S3Client.swift
@@ -99,13 +99,15 @@ public struct S3Client: RequestPerformer {
         objectAtPath path: URL,
         toBucket bucket: String,
         key: String,
+        allowResume: Bool = true,
         progressCallback: ProgressCallback? = nil
     ) async throws {
         let operation = try MultipartUploadOperation(
             bucket: bucket,
             key: key,
             path: path,
-            credentials: self.credentials
+            credentials: self.credentials,
+            allowResume: allowResume
         )
 
         try await operation.start(progressCallback)

--- a/Sources/tinys3/model/Multipart/PartSizeCalculator.swift
+++ b/Sources/tinys3/model/Multipart/PartSizeCalculator.swift
@@ -2,6 +2,6 @@ import Foundation
 
 struct PartSizeCalculator {
     static func calculate(basedOn fileSize: Int) -> Int {
-        max(min(fileSize, 5_000_000), min(4_900_000_000, fileSize / 12))
+        max(min(fileSize, 5_000_000), min(4_900_000_000, fileSize / 50))
     }
 }

--- a/Sources/tinys3/responses/S3ListMultipartUploadResponse.swift
+++ b/Sources/tinys3/responses/S3ListMultipartUploadResponse.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+#if canImport(FoundationXML)
+import FoundationXML
+#endif
+
+struct S3ListMultipartUploadResponse {
+
+    struct S3MultipartUpload {
+        let key: String
+        let uploadId: String
+        let initiatedDate: Date
+    }
+    let bucket: String
+    let uploads: [S3MultipartUpload]
+
+    static func from(response: AWSResponse) throws -> S3ListMultipartUploadResponse {
+        let doc = try XMLDocument(data: response.data)
+        guard let root = doc.rootElement(), root.name == "ListMultipartUploadsResult" else {
+            throw InvalidDataError()
+        }
+        
+        guard let bucketNode = root.elements(forName: "Bucket").first, let bucketName = bucketNode.stringValue else {
+            throw InvalidDataError()
+        }
+        
+        let uploads = try root.elements(forName: "Upload").map {
+            guard
+                let key = $0.elements(forName: "Key").first?.stringValue,
+                let uploadId = $0.elements(forName: "UploadId").first?.stringValue,
+                let initiatedString = $0.elements(forName: "Initiated").first?.stringValue,
+                let initiatedDate = parseISO8601String(initiatedString)
+            else {
+                throw InvalidDataError()
+            }
+            return S3MultipartUpload(key: key, uploadId: uploadId, initiatedDate: initiatedDate)
+        }
+        
+        return S3ListMultipartUploadResponse(bucket: bucketName, uploads: uploads)
+    }
+    
+    var mostRecentUpload: S3MultipartUpload? {
+        self.uploads.max { $0.initiatedDate < $1.initiatedDate }
+    }
+}

--- a/Sources/tinys3/responses/S3ListMultipartUploadResponse.swift
+++ b/Sources/tinys3/responses/S3ListMultipartUploadResponse.swift
@@ -11,6 +11,7 @@ struct S3ListMultipartUploadResponse {
         let uploadId: String
         let initiatedDate: Date
     }
+
     let bucket: String
     let uploads: [S3MultipartUpload]
 

--- a/Sources/tinys3/responses/S3ListMultipartUploadResponse.swift
+++ b/Sources/tinys3/responses/S3ListMultipartUploadResponse.swift
@@ -20,11 +20,11 @@ struct S3ListMultipartUploadResponse {
         guard let root = doc.rootElement(), root.name == "ListMultipartUploadsResult" else {
             throw InvalidDataError()
         }
-        
+
         guard let bucketNode = root.elements(forName: "Bucket").first, let bucketName = bucketNode.stringValue else {
             throw InvalidDataError()
         }
-        
+
         let uploads = try root.elements(forName: "Upload").map {
             guard
                 let key = $0.elements(forName: "Key").first?.stringValue,
@@ -36,10 +36,10 @@ struct S3ListMultipartUploadResponse {
             }
             return S3MultipartUpload(key: key, uploadId: uploadId, initiatedDate: initiatedDate)
         }
-        
+
         return S3ListMultipartUploadResponse(bucket: bucketName, uploads: uploads)
     }
-    
+
     var mostRecentUpload: S3MultipartUpload? {
         self.uploads.max { $0.initiatedDate < $1.initiatedDate }
     }

--- a/Sources/tinys3/responses/S3ListPartsResponse.swift
+++ b/Sources/tinys3/responses/S3ListPartsResponse.swift
@@ -11,6 +11,7 @@ struct S3ListPartsResponse {
         let uploadId: String
         let initiatedDate: Date
     }
+
     let bucket: String
     let key: String
     let uploadId: String

--- a/Sources/tinys3/responses/S3ListPartsResponse.swift
+++ b/Sources/tinys3/responses/S3ListPartsResponse.swift
@@ -22,7 +22,7 @@ struct S3ListPartsResponse {
         guard let root = doc.rootElement(), root.name == "ListPartsResult" else {
             throw InvalidDataError()
         }
-        
+
         guard let bucketName = root.elements(forName: "Bucket").first?.stringValue else {
             throw InvalidDataError()
         }
@@ -32,7 +32,7 @@ struct S3ListPartsResponse {
         guard let uploadId = root.elements(forName: "UploadId").first?.stringValue else {
             throw InvalidDataError()
         }
-        
+
         let parts = try root.elements(forName: "Part").map {
             guard
                 let partString = $0.elements(forName: "PartNumber").first?.stringValue,
@@ -43,7 +43,7 @@ struct S3ListPartsResponse {
             }
             return MultipartUploadOperation.AWSUploadedPart(number: partNum, eTag: eTag)
         }
-        
+
         return S3ListPartsResponse(
             bucket: bucketName,
             key: objectKey,

--- a/Sources/tinys3/responses/S3ListPartsResponse.swift
+++ b/Sources/tinys3/responses/S3ListPartsResponse.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+#if canImport(FoundationXML)
+import FoundationXML
+#endif
+
+struct S3ListPartsResponse {
+
+    struct S3MultipartUpload {
+        let key: String
+        let uploadId: String
+        let initiatedDate: Date
+    }
+    let bucket: String
+    let key: String
+    let uploadId: String
+    let parts: [MultipartUploadOperation.AWSUploadedPart]
+
+    static func from(response: AWSResponse) throws -> S3ListPartsResponse {
+        let doc = try XMLDocument(data: response.data)
+        guard let root = doc.rootElement(), root.name == "ListPartsResult" else {
+            throw InvalidDataError()
+        }
+        
+        guard let bucketName = root.elements(forName: "Bucket").first?.stringValue else {
+            throw InvalidDataError()
+        }
+        guard let objectKey = root.elements(forName: "Key").first?.stringValue else {
+            throw InvalidDataError()
+        }
+        guard let uploadId = root.elements(forName: "UploadId").first?.stringValue else {
+            throw InvalidDataError()
+        }
+        
+        let parts = try root.elements(forName: "Part").map {
+            guard
+                let partString = $0.elements(forName: "PartNumber").first?.stringValue,
+                let partNum = Int(partString),
+                let eTag = $0.elements(forName: "ETag").first?.stringValue
+            else {
+                throw InvalidDataError()
+            }
+            return MultipartUploadOperation.AWSUploadedPart(number: partNum, eTag: eTag)
+        }
+        
+        return S3ListPartsResponse(
+            bucket: bucketName,
+            key: objectKey,
+            uploadId: uploadId,
+            parts: parts
+        )
+    }
+}

--- a/Tests/tinys3Tests/model/MultipartUploadFileTests.swift
+++ b/Tests/tinys3Tests/model/MultipartUploadFileTests.swift
@@ -51,9 +51,9 @@ final class MultipartUploadFileTests: XCTestCase {
         XCTAssertEqual(PartSizeCalculator.calculate(basedOn: 4094), 4094)                     //    4kb
         XCTAssertEqual(PartSizeCalculator.calculate(basedOn: 4_094_000), 4_094_000)           //    4mb
         XCTAssertEqual(PartSizeCalculator.calculate(basedOn: 40_094_000), 5_000_000)          //   40mb
-        XCTAssertEqual(PartSizeCalculator.calculate(basedOn: 400_094_000), 33_341_166)        //  400mb
-        XCTAssertEqual(PartSizeCalculator.calculate(basedOn: 4_000_094_000), 333_341_166)     //    4gb
-        XCTAssertEqual(PartSizeCalculator.calculate(basedOn: 40_000_094_000), 3_333_341_166)  //   40gb
+        XCTAssertEqual(PartSizeCalculator.calculate(basedOn: 400_094_000), 8_001_880)         //  400mb
+        XCTAssertEqual(PartSizeCalculator.calculate(basedOn: 4_000_094_000), 80_001_880)      //    4gb
+        XCTAssertEqual(PartSizeCalculator.calculate(basedOn: 40_000_094_000), 800_001_880)    //   40gb
         XCTAssertEqual(PartSizeCalculator.calculate(basedOn: 400_000_094_000), 4_900_000_000) //  400gb
         XCTAssertEqual(PartSizeCalculator.calculate(basedOn: 400_000_094_000), 4_900_000_000) //    4tb
     }


### PR DESCRIPTION
Quick implementation of a resume mechanism for `hostmgr vm publish`.

Closes https://github.com/Automattic/hostmgr/issues/86

_Note: This PR sits on top of https://github.com/Automattic/hostmgr/pull/88 and targets the `vm-list-cleanup` branch, to avoid conflicts while working on those different features of the codebase._

## How it works

 - When we ask tinys3 to start a (multipart) upload, instead of immediately issuing a `CreateMultipartUploadRequest`, it first checks if there is an existing `ListMultipartUploadRequest` matching the destination (`key`) to which we want to upload.
 - If it finds at least one, it picks the most recent of those uncompleted uploads for this `key`, then uses `ListPartsRequest` to fetch all the parts already uploaded for that multipart upload request. If it doesn't find one, then it initiates a `CreateMultipartUploadRequest` as before
 - When calling `uploadPart`, we now also pass the existing `AWSUploadedPart` candidate, if one exists (i.e. if a previous upload was found and that part index was present in it). This is then used to check if the ETags/MD5 checksums of the existing candidate still matches the md5 of the part we're about to upload, and if so, skip the upload of that already-uploaded part.