### PR TITLE
Simplify XML parsing code

### DIFF
--- a/Sources/tinys3/Helpers.swift
+++ b/Sources/tinys3/Helpers.swift
@@ -3,25 +3,6 @@ import Crypto
 
 struct InvalidDataError: Error {}
 
-struct XMLDataValidator {
-
-    var expectedRootElementName: String
-    var wasTriggered: Bool = false
-
-    mutating func validate(elementName: String, failureHandler: (Error) -> Void) {
-        guard !wasTriggered else {
-            return
-        }
-
-        self.wasTriggered = true
-
-        guard elementName == expectedRootElementName else {
-            failureHandler(InvalidDataError())
-            return
-        }
-    }
-}
-
 func sha256Hash(fileAt url: URL) throws -> String {
     var hasher = SHA256()
 

--- a/Sources/tinys3/responses/S3CreateMultipartUploadResponse.swift
+++ b/Sources/tinys3/responses/S3CreateMultipartUploadResponse.swift
@@ -12,22 +12,12 @@ struct S3CreateMultipartUploadResponse {
 
     static func from(response: AWSResponse) throws -> S3CreateMultipartUploadResponse {
         let doc = try XMLDocument(data: response.data)
-        guard let root = doc.rootElement(), root.name == "InitiateMultipartUploadResult" else {
-            throw InvalidDataError()
-        }
-
-        guard
-            let bucket = root.elements(forName: "Bucket").first?.stringValue,
-            let key = root.elements(forName: "Key").first?.stringValue,
-            let uploadId = root.elements(forName: "UploadId").first?.stringValue
-        else {
-            throw InvalidDataError()
-        }
+        let root = try doc.rootElement(expectedName: "InitiateMultipartUploadResult")
 
         return S3CreateMultipartUploadResponse(
-            bucket: bucket,
-            key: key,
-            uploadId: uploadId
+            bucket: try root.value(forElementName: "Bucket"),
+            key: try root.value(forElementName: "Key"),
+            uploadId: try root.value(forElementName: "UploadId")
         )
     }
 }

--- a/Sources/tinys3/responses/S3CreateMultipartUploadResponse.swift
+++ b/Sources/tinys3/responses/S3CreateMultipartUploadResponse.swift
@@ -11,31 +11,15 @@ struct S3CreateMultipartUploadResponse {
     let uploadId: String
 
     static func from(response: AWSResponse) throws -> S3CreateMultipartUploadResponse {
-        return try S3CreateMultipartUploadResponseParser(data: response.data).parse()
-    }
-}
-
-class S3CreateMultipartUploadResponseParser: NSObject {
-    private let parser: XMLParser
-
-    init(data: Data) {
-        self.parser = XMLParser(data: data)
-        super.init()
-        self.parser.delegate = self
-    }
-
-    @discardableResult
-    func parse() throws -> S3CreateMultipartUploadResponse {
-        _ = self.parser.parse()
-
-        if let error = self.parser.parserError {
-            throw error
+        let doc = try XMLDocument(data: response.data)
+        guard let root = doc.rootElement(), root.name == "InitiateMultipartUploadResult" else {
+            throw InvalidDataError()
         }
 
         guard
-            let bucket = self.bucket,
-            let key = self.key,
-            let uploadId = self.uploadId
+            let bucket = root.elements(forName: "Bucket").first?.stringValue,
+            let key = root.elements(forName: "Key").first?.stringValue,
+            let uploadId = root.elements(forName: "UploadId").first?.stringValue
         else {
             throw InvalidDataError()
         }
@@ -45,68 +29,5 @@ class S3CreateMultipartUploadResponseParser: NSObject {
             key: key,
             uploadId: uploadId
         )
-    }
-
-    // MARK: Error Elements
-    var bucket: String?
-    var key: String?
-    var uploadId: String?
-
-    var error: Error?
-
-    var currentElement: ParserElement?
-    var rootElementValidator = XMLDataValidator(expectedRootElementName: ParserElement.root.rawValue)
-}
-
-extension S3CreateMultipartUploadResponseParser: XMLParserDelegate {
-    enum ParserElement: String {
-        case root = "InitiateMultipartUploadResult"
-        case bucket = "Bucket"
-        case key = "Key"
-        case uploadId = "UploadId"
-    }
-
-    func parser(
-        _ parser: XMLParser,
-        didStartElement elementName: String,
-        namespaceURI: String?,
-        qualifiedName qName: String?,
-        attributes attributeDict: [String: String] = [:]
-    ) {
-        self.currentElement = ParserElement(rawValue: elementName)
-
-        self.rootElementValidator.validate(elementName: elementName) { error in
-            self.parser(parser, parseErrorOccurred: error)
-        }
-    }
-
-    func parser(
-        _ parser: XMLParser,
-        parseErrorOccurred error: Error
-    ) {
-        self.error = error
-        parser.abortParsing()
-    }
-
-    func parser(
-        _ parser: XMLParser,
-        didEndElement elementName: String,
-        namespaceURI: String?,
-        qualifiedName qName: String?
-    ) {
-        self.currentElement = nil // Without this, we'll store the whitespace beween elements
-    }
-
-    func parser(_ parser: XMLParser, foundCharacters string: String) {
-        guard let currentElement = self.currentElement else {
-            return
-        }
-
-        switch currentElement {
-        case .bucket: self.bucket = string
-        case .key: self.key = string
-        case .uploadId: self.uploadId = string
-        case .root: break
-        }
     }
 }

--- a/Sources/tinys3/responses/S3ErrorResponse.swift
+++ b/Sources/tinys3/responses/S3ErrorResponse.swift
@@ -15,113 +15,32 @@ struct S3ErrorResponse: Error {
     let extra: [String: String]
 
     static func from(response: AWSResponse) throws -> S3ErrorResponse {
-        return try S3ErrorResponseParser(data: response.data).parse()
-    }
-}
+        let doc = try XMLDocument(data: response.data)
 
-class S3ErrorResponseParser: NSObject {
-    private let parser: XMLParser
-
-    init(data: Data) {
-        self.parser = XMLParser(data: data)
-        super.init()
-        self.parser.delegate = self
-    }
-
-    @discardableResult
-    func parse() throws -> S3ErrorResponse {
-        _ = self.parser.parse()
-
-        if let error = self.parser.parserError ?? self.error {
-            throw error
+        guard let root = doc.rootElement(), root.name == "Error" else {
+            throw InvalidDataError()
         }
 
         guard
-            let code = self.code,
-            let message = self.message,
-            let requestId = self.requestId,
-            let hostId = self.hostId
+            let code = root.elements(forName: "Code").first?.stringValue,
+            let message = root.elements(forName: "Message").first?.stringValue,
+            let requestId = root.elements(forName: "RequestId").first?.stringValue,
+            let hostId = root.elements(forName: "HostId").first?.stringValue
         else {
             throw InvalidDataError()
         }
+
+        var extra = [String: String]()
+        extra["Endpoint"] = root.elements(forName: "Endpoint").first?.stringValue
+        extra["Bucket"] = root.elements(forName: "Bucket").first?.stringValue
+        extra["Key"] = root.elements(forName: "Key").first?.stringValue
 
         return S3ErrorResponse(
             code: code,
             message: message,
             requestId: requestId,
             hostId: hostId,
-            extra: self.extra
+            extra: extra
         )
-    }
-
-    // MARK: Error Elements
-    var code: String?
-    var message: String?
-    var hostId: String?
-    var requestId: String?
-
-    var extra: [String: String] = [:]
-    var error: Error?
-
-    var currentElement: ParserElement?
-    var rootElementValidator = XMLDataValidator(expectedRootElementName: ParserElement.root.rawValue)
-}
-
-extension S3ErrorResponseParser: XMLParserDelegate {
-    enum ParserElement: String {
-        case root = "Error"
-        case code = "Code"
-        case message = "Message"
-        case requestId = "RequestId"
-        case hostID = "HostId"
-
-        // Extras
-        case endpoint = "Endpoint"
-        case bucket = "Bucket"
-        case key = "Key"
-    }
-
-    func parser(
-        _ parser: XMLParser,
-        didStartElement elementName: String,
-        namespaceURI: String?,
-        qualifiedName qName: String?,
-        attributes attributeDict: [String: String] = [:]
-    ) {
-        self.currentElement = ParserElement(rawValue: elementName)
-
-        self.rootElementValidator.validate(elementName: elementName) { error in
-            self.parser(parser, parseErrorOccurred: error)
-        }
-    }
-
-    func parser(
-        _ parser: XMLParser,
-        parseErrorOccurred error: Error
-    ) {
-        self.error = error
-        parser.abortParsing()
-    }
-
-    func parser(
-        _ parser: XMLParser,
-        didEndElement elementName: String,
-        namespaceURI: String?,
-        qualifiedName qName: String?
-    ) {
-        self.currentElement = nil // Without this, we'll store the whitespace beween elements
-    }
-
-    func parser(_ parser: XMLParser, foundCharacters string: String) {
-        switch self.currentElement {
-        case .code: self.code = string
-        case .message: self.message = string
-        case .requestId: self.requestId = string
-        case .hostID: self.hostId = string
-        default:
-            if let element = self.currentElement {
-                self.extra[element.rawValue] = string
-            }
-        }
     }
 }

--- a/Sources/tinys3/responses/S3ListMultipartUploadResponse.swift
+++ b/Sources/tinys3/responses/S3ListMultipartUploadResponse.swift
@@ -29,8 +29,7 @@ struct S3ListMultipartUploadResponse {
             guard
                 let key = $0.elements(forName: "Key").first?.stringValue,
                 let uploadId = $0.elements(forName: "UploadId").first?.stringValue,
-                let initiatedString = $0.elements(forName: "Initiated").first?.stringValue,
-                let initiatedDate = parseISO8601String(initiatedString)
+                let initiatedDate = $0.elements(forName: "Initiated").first?.stringValue.flatMap(parseISO8601String)
             else {
                 throw InvalidDataError()
             }

--- a/Sources/tinys3/responses/S3ListMultipartUploadResponse.swift
+++ b/Sources/tinys3/responses/S3ListMultipartUploadResponse.swift
@@ -17,26 +17,20 @@ struct S3ListMultipartUploadResponse {
 
     static func from(response: AWSResponse) throws -> S3ListMultipartUploadResponse {
         let doc = try XMLDocument(data: response.data)
-        guard let root = doc.rootElement(), root.name == "ListMultipartUploadsResult" else {
-            throw InvalidDataError()
-        }
-
-        guard let bucketNode = root.elements(forName: "Bucket").first, let bucketName = bucketNode.stringValue else {
-            throw InvalidDataError()
-        }
+        let root = try doc.rootElement(expectedName: "ListMultipartUploadsResult")
 
         let uploads = try root.elements(forName: "Upload").map {
-            guard
-                let key = $0.elements(forName: "Key").first?.stringValue,
-                let uploadId = $0.elements(forName: "UploadId").first?.stringValue,
-                let initiatedDate = $0.elements(forName: "Initiated").first?.stringValue.flatMap(parseISO8601String)
-            else {
-                throw InvalidDataError()
-            }
-            return S3MultipartUpload(key: key, uploadId: uploadId, initiatedDate: initiatedDate)
+            S3MultipartUpload(
+                key: try $0.value(forElementName: "Key"),
+                uploadId: try $0.value(forElementName: "UploadId"),
+                initiatedDate: try $0.value(forElementName: "Initiated", transform: parseISO8601String)
+            )
         }
 
-        return S3ListMultipartUploadResponse(bucket: bucketName, uploads: uploads)
+        return S3ListMultipartUploadResponse(
+            bucket: try root.value(forElementName: "Bucket"),
+            uploads: uploads
+        )
     }
 
     var mostRecentUpload: S3MultipartUpload? {

--- a/Sources/tinys3/responses/S3ListPartsResponse.swift
+++ b/Sources/tinys3/responses/S3ListPartsResponse.swift
@@ -23,25 +23,22 @@ struct S3ListPartsResponse {
             throw InvalidDataError()
         }
 
-        guard let bucketName = root.elements(forName: "Bucket").first?.stringValue else {
-            throw InvalidDataError()
-        }
-        guard let objectKey = root.elements(forName: "Key").first?.stringValue else {
-            throw InvalidDataError()
-        }
-        guard let uploadId = root.elements(forName: "UploadId").first?.stringValue else {
+        guard
+            let bucketName = root.elements(forName: "Bucket").first?.stringValue,
+            let objectKey = root.elements(forName: "Key").first?.stringValue,
+            let uploadId = root.elements(forName: "UploadId").first?.stringValue
+        else {
             throw InvalidDataError()
         }
 
         let parts = try root.elements(forName: "Part").map {
             guard
-                let partString = $0.elements(forName: "PartNumber").first?.stringValue,
-                let partNum = Int(partString),
+                let partNumber = $0.elements(forName: "PartNumber").first?.stringValue.flatMap({ Int($0) }),
                 let eTag = $0.elements(forName: "ETag").first?.stringValue
             else {
                 throw InvalidDataError()
             }
-            return MultipartUploadOperation.AWSUploadedPart(number: partNum, eTag: eTag)
+            return MultipartUploadOperation.AWSUploadedPart(number: partNumber, eTag: eTag)
         }
 
         return S3ListPartsResponse(

--- a/Sources/tinys3/responses/S3ListResponse.swift
+++ b/Sources/tinys3/responses/S3ListResponse.swift
@@ -14,157 +14,49 @@ public struct S3ListResponse {
     public let objects: [S3Object]
 
     static func from(response: AWSResponse) throws -> S3ListResponse {
-        try S3ListResponseParser(data: response.data).parse()
-    }
-}
-
-class S3ListResponseParser: NSObject {
-
-    private let parser: XMLParser
-
-    init(data: Data) {
-        self.parser = XMLParser(data: data)
-        super.init()
-
-        self.parser.delegate = self
-    }
-
-    @discardableResult
-    func parse() throws -> S3ListResponse {
-        _ = self.parser.parse()
-
-        if let error = self.parser.parserError ?? self.error {
-            throw error
+        let doc = try XMLDocument(data: response.data)
+        guard let root = doc.rootElement(), root.name == "ListBucketResult" else {
+            throw InvalidDataError()
         }
 
         guard
-            let bucketName = self.name,
-            let maxKeys = self.maxKeys,
-            let isTruncated = self.truncated
+            let bucketName = root.elements(forName: "Name").first?.stringValue,
+            let maxKeys = root.elements(forName: "MaxKeys").first?.stringValue.flatMap({ Int($0) }),
+            let isTruncated = root.elements(forName: "IsTruncated").first?.stringValue.flatMap({ Bool($0) })
         else {
             throw InvalidDataError()
         }
 
+        let prefix = root.elements(forName: "Prefix").first?.stringValue
+        let marker = root.elements(forName: "Marker").first?.stringValue
+
+        let objects = try root.elements(forName: "Contents").map { node in
+            guard
+                let key = node.elements(forName: "Key").first?.stringValue,
+                let size = node.elements(forName: "Size").first?.stringValue.flatMap({ Int($0) }),
+                let eTag = node.elements(forName: "ETag").first?.stringValue,
+                let lastModified = node.elements(forName: "LastModified").first?.stringValue.flatMap(parseISO8601String),
+                let storageClass = node.elements(forName: "StorageClass").first?.stringValue
+            else {
+                throw InvalidDataError()
+            }
+
+            return S3Object(
+                key: key,
+                size: size,
+                eTag: eTag,
+                lastModifiedAt: lastModified,
+                storageClass: storageClass
+            )
+        }
+
         return S3ListResponse(
             bucketName: bucketName,
-            prefix: self.prefix,
-            marker: self.marker,
+            prefix: prefix?.isEmpty == true ? nil : prefix,
+            marker: marker?.isEmpty == true ? nil : marker,
             maxKeys: maxKeys,
             isTruncated: isTruncated,
-            objects: self.objects
+            objects: objects
         )
-    }
-
-    // MARK: Header Elements
-    var name: String?
-    var prefix: String?
-    var maxKeys: Int?
-    var truncated: Bool?
-    var marker: String?
-
-    // MARK: Contents Elements
-    var key: String?
-    var lastModified: Date?
-    var eTag: String?
-    var size: Int?
-    var storageClass: String?
-
-    var currentElement: ParserElement?
-
-    var objects: [S3Object] = []
-
-    var rootElementValidator = XMLDataValidator(expectedRootElementName: ParserElement.root.rawValue)
-    var error: Error?
-}
-
-extension S3ListResponseParser: XMLParserDelegate {
-
-    enum ParserElement: String {
-        case root = "ListBucketResult"
-        case contents = "Contents"
-        case name = "Name"
-        case prefix = "Prefix"
-        case maxKeys = "MaxKeys"
-        case truncated = "IsTruncated"
-        case marker = "Marker"
-        case key = "Key"
-        case lastModified = "LastModified"
-        case eTag = "ETag"
-        case size = "Size"
-        case storageClass = "StorageClass"
-    }
-
-    func parser(
-        _ parser: XMLParser,
-        didStartElement elementName: String,
-        namespaceURI: String?,
-        qualifiedName qName: String?,
-        attributes attributeDict: [String: String] = [:]
-    ) {
-        self.currentElement = ParserElement(rawValue: elementName)
-
-        self.rootElementValidator.validate(elementName: elementName) { error in
-            self.parser(parser, parseErrorOccurred: error)
-        }
-    }
-
-    func parser(
-        _ parser: XMLParser,
-        didEndElement elementName: String,
-        namespaceURI: String?,
-        qualifiedName qName: String?
-    ) {
-        guard
-            let element = ParserElement(rawValue: elementName),
-            element == .contents, // We only need to finalize the `Contents` element
-
-            let key = self.key,
-            let size = self.size,
-            let eTag = self.eTag,
-            let lastModified = self.lastModified,
-            let storageClass = self.storageClass
-
-        else {
-            self.currentElement = nil // Without this, we'll store whitespace beween elements
-            return
-        }
-
-        self.objects.append(S3Object(
-            key: key,
-            size: size,
-            eTag: eTag,
-            lastModifiedAt: lastModified,
-            storageClass: storageClass
-        ))
-
-        // Reset all values before we start parsing the next object
-        self.key = nil
-        self.lastModified = nil
-        self.eTag = nil
-        self.size = nil
-        self.storageClass = nil
-    }
-
-    // swiftlint:disable cyclomatic_complexity
-    func parser(_ parser: XMLParser, foundCharacters string: String) {
-        switch self.currentElement {
-        case .name: self.name = string
-        case .prefix: self.prefix = string
-        case .maxKeys: self.maxKeys = Int(string)
-        case .truncated: self.truncated = Bool(string)
-        case .marker: self.marker = string
-        case .key: self.key = string
-        case .lastModified: self.lastModified = parseISO8601String(string)
-        case .eTag: self.eTag = string
-        case .size: self.size = Int(string)
-        case .storageClass: self.storageClass = string
-        default: break
-        }
-    }
-    // swiftlint:enable cyclomatic_complexity
-
-    func parser(_ parser: XMLParser, parseErrorOccurred error: Error) {
-        self.error = error
-        parser.abortParsing()
     }
 }


### PR DESCRIPTION
Migrate all AWSResponses XML parsing from SAX (`XMLParser` + `delegate`) to DOM (`XMLDocument`)

This is an approach that I've started to use when I [implemented additional AWS requests for resumable upload support](https://github.com/Automattic/hostmgr/pull/89), and it simplifies the parsing code drastically, so I figured I'd migrate existing parsers to use this approach too.

---
_Note: This builds on top of https://github.com/Automattic/hostmgr/pull/90 / `refine-tests` branch—so that we benefit from tests not referencing internal Parser implementations (that used a SAX `XMLParser`) anymore._