### PR TITLE
Fix Multipart slicing logic / off-by-one errors

### DIFF
--- a/Sources/tinys3/model/Multipart/MultipartUploadFile.swift
+++ b/Sources/tinys3/model/Multipart/MultipartUploadFile.swift
@@ -20,10 +20,10 @@ actor MultipartUploadFile {
         var parts = [Range<Int>]()
 
         while rangeEnd < fileSize {
-            rangeStart = (parts.last?.upperBound ?? -1) + 1
+            rangeStart = (parts.last?.upperBound ?? 0)
             rangeEnd = rangeStart + partSize
 
-            parts.append(rangeStart..<rangeEnd)
+            parts.append(rangeStart..<min(rangeEnd, fileSize))
         }
 
         return parts
@@ -38,7 +38,7 @@ actor MultipartUploadFile {
             try handle.seek(toOffset: UInt64(range.lowerBound))
 
             if #available(macOS 10.15.4, *) {
-                guard let data = try handle.read(upToCount: range.count + 1) else {
+                guard let data = try handle.read(upToCount: range.count) else {
                     throw CocoaError(.fileReadUnknown)
                 }
 

--- a/Sources/tinys3/model/Multipart/MultipartUploadFile.swift
+++ b/Sources/tinys3/model/Multipart/MultipartUploadFile.swift
@@ -5,13 +5,12 @@ actor MultipartUploadFile {
     let fileSize: Int
     let partSize: Int
 
-    init(path: URL, partSize: Int? = nil) throws {
+    init(path: URL, partSize: Int? = nil, fileSize: Int? = nil) throws {
         self.handle = try FileHandle(forReadingFrom: path)
 
-        let fileSize = try FileManager.default.fileSize(of: path)
-
-        self.fileSize = fileSize
-        self.partSize = PartSizeCalculator.calculate(basedOn: fileSize)
+        let fileSizeUsed = try fileSize ?? FileManager.default.fileSize(of: path)
+        self.fileSize = fileSizeUsed
+        self.partSize = partSize ?? PartSizeCalculator.calculate(basedOn: fileSizeUsed)
     }
 
     var parts: [Range<Int>] {

--- a/Sources/tinys3/model/Multipart/MultipartUploadFile.swift
+++ b/Sources/tinys3/model/Multipart/MultipartUploadFile.swift
@@ -14,19 +14,8 @@ actor MultipartUploadFile {
     }
 
     var parts: [Range<Int>] {
-        var rangeStart = 0
-        var rangeEnd = -1
-
-        var parts = [Range<Int>]()
-
-        while rangeEnd < fileSize {
-            rangeStart = (parts.last?.upperBound ?? 0)
-            rangeEnd = rangeStart + partSize
-
-            parts.append(rangeStart..<min(rangeEnd, fileSize))
-        }
-
-        return parts
+        stride(from: 0, to: fileSize, by: partSize)
+            .map { start in start ..< min(start + partSize, fileSize) }
     }
 
     var uploadParts: [(Int, Range<Int>)] {

--- a/Sources/tinys3/model/Multipart/PartSizeCalculator.swift
+++ b/Sources/tinys3/model/Multipart/PartSizeCalculator.swift
@@ -7,23 +7,23 @@ enum PartSizeCalculator {
     static let typicalNumberOfParts = 500
 
     static func calculate(basedOn fileSize: Int) -> Int {
-        max(min(fileSize, minPartSize), min(fileSize / typicalNumberOfParts, maxPartSize))
+        max(minPartSize, min(fileSize / typicalNumberOfParts, maxPartSize))
     }
 }
 
-/*
-     ^
-     |       N = typicalNumberOfParts
-     |
- 5GB |                                    _______________________
-     |                               ____/
-     |                          ____/     '
-     |                     ____/          '
-     |                ____/               '
- 5MB |   ------------'                    '
-     |  /            '                    '
-     | /             '                    '
-     |/ '            '                    '
-     +--+------------+--------------------+----------------------------->
-       5MB         5MB*N                5GB*N
+/* Part Size
+       ^
+       |       N = typicalNumberOfParts
+       |
+   5GB |                                     _______________________
+       |                                ____/
+       |                           ____/     '
+       |                      ____/          '
+       |                 ____/               '
+   5MB |----------------'                    '
+       |                '                    '
+       |                '                    '
+       |                '                    '
+       +----------------+--------------------+----------------------------->
+                      5MB*N                5GB*N                     File Size
  */


### PR DESCRIPTION
This PR builds on top of https://github.com/Automattic/hostmgr/pull/92 and is a followup of https://github.com/Automattic/hostmgr/pull/92#discussion_r1550266186, which made me notice that there was an off-by-one error in the logic slicing the data into parts. 

## The off-by-one error

 - The way the `Range<Int>` were used in the implementation of `subscript` made them in practice be interpreted as `ClosedRange<Int>`, including the upper bound
 - The amount of bytes read from the `FileHandle` to constitute each part were thus 1 byte more than the `partSize` we computed

## Red/Green/Refactoring

I approached this using some R/G/R:
- Red: Add (failing) tests to cover those cases — 3a225361ba48b2b40ea86b96dfd93c3a896b7cbe
- Green: Fix implementation to pass the added tests — 154de58748f936f3891d57080148cfe9d412af97
- Refactoring: Simplify slicing implementation using the stdlib's `stride(…)` method — f129e7cbbaea4863424f6ef88008a061cc3e6d13
