### PR TITLE
Make GitHub Releases be lastest and not pre-releases

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -45,7 +45,7 @@ lane :upload_release do |_options|
     tag_name: tag,
     description: Digest::SHA256.file(ZIP_FILE_PATH).to_s,
     upload_assets: [ZIP_FILE_PATH] + ARTIFACT_PATHS,
-    is_prerelease: true
+    is_prerelease: false
   )
 end
 


### PR DESCRIPTION
When generating the tag for `0.50.1` I noticed that the GitHub Release was created as a Pre-Release instead of being marked as the latest version.