### PR TITLE
Disable Git Mirror upload resume

### DIFF
--- a/Sources/hostmgr/commands/cache/GitMirrorPublishCommand.swift
+++ b/Sources/hostmgr/commands/cache/GitMirrorPublishCommand.swift
@@ -50,7 +50,12 @@ struct GitMirrorPublishCommand: AsyncParsableCommand {
         }
 
         let progress = Console.startProgress("Uploading mirror to \(gitMirror.remoteFilename)", type: .upload)
-        try await server.uploadFile(at: gitMirror.archivePath, to: gitMirror.remoteFilename, allowResume: false, progress: progress.update)
+        try await server.uploadFile(
+            at: gitMirror.archivePath,
+            to: gitMirror.remoteFilename,
+            allowResume: false,
+            progress: progress.update
+        )
 
         Console.success("Upload complete")
     }

--- a/Sources/hostmgr/commands/cache/GitMirrorPublishCommand.swift
+++ b/Sources/hostmgr/commands/cache/GitMirrorPublishCommand.swift
@@ -53,6 +53,10 @@ struct GitMirrorPublishCommand: AsyncParsableCommand {
         try await server.uploadFile(
             at: gitMirror.archivePath,
             to: gitMirror.remoteFilename,
+            // See https://github.com/Automattic/hostmgr/issues/102
+            // For the case of git mirrors, since those are published by Buildkite jobs during `post-checkout`,
+            // there isn't much sense in allowing resume for them anyway—as even if they fail on a given job,
+            // that job won't re-run the `publish-git-mirror` command again on failure.
             allowResume: false,
             progress: progress.update
         )

--- a/Sources/hostmgr/commands/cache/GitMirrorPublishCommand.swift
+++ b/Sources/hostmgr/commands/cache/GitMirrorPublishCommand.swift
@@ -50,7 +50,7 @@ struct GitMirrorPublishCommand: AsyncParsableCommand {
         }
 
         let progress = Console.startProgress("Uploading mirror to \(gitMirror.remoteFilename)", type: .upload)
-        try await server.uploadFile(at: gitMirror.archivePath, to: gitMirror.remoteFilename, progress: progress.update)
+        try await server.uploadFile(at: gitMirror.archivePath, to: gitMirror.remoteFilename, allowResume: false, progress: progress.update)
 
         Console.success("Upload complete")
     }


### PR DESCRIPTION
Context: p1717455440382939/1714552456.261469-slack-CC7L49W13

To help validating the hypothesis we are currently have in https://github.com/Automattic/hostmgr/issues/102 (**and to have a fix before the end of the month this weekend**), I'll disable the resume for git mirror uploads.

~This change will likely be temporary, allowing us to have a proper fix for next month's Git Mirror update.~

Once this is merged, I'll create and deploy a new hostmgr `0.50.2` so that everything is ready for the weekend 🤞 