### PR TITLE
Use linter agent and improve lint config

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -26,19 +26,14 @@ steps:
   # Lint
   #################
   - label: "🧪 Lint Swift"
-    command: |
-      make lint-swift
-    plugins: *common_plugins
+    command: swiftlint
     agents:
-      queue: default
+      queue: "linter"
 
   - label: "🧪 Lint Ruby"
-    command: |
-      make lint-ruby
-    env: *common_env
-    plugins: *common_plugins
+    command: rubocop
     agents:
-      queue: default
+      queue: "linter"
 
   #################
   # Validate Release Build

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,5 +13,8 @@ AllCops:
   NewCops: enable
   Include:
     - 'fastlane/Fastfile'
-  TargetRubyVersion: 2.7.4
+  TargetRubyVersion: 3.2.2
   SuggestExtensions: false
+
+Style/HashSyntax:
+  EnforcedShorthandSyntax: never

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,4 +1,4 @@
-swiftlint_version: 0.53.0
+swiftlint_version: 0.54.0
 included:
   - Sources
   - Tests

--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,4 @@ source 'https://rubygems.org'
 gem 'aws-sdk-s3', '~> 1.119'
 gem 'fastlane', '~> 2.212'
 
-gem 'rubocop', '~> 1.42', require: false
+gem 'rubocop', '~> 1.64', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,24 +165,25 @@ GEM
     nkf (0.2.0)
     optparse (0.5.0)
     os (1.1.4)
-    parallel (1.24.0)
-    parser (3.3.0.5)
+    parallel (1.25.1)
+    parser (3.3.3.0)
       ast (~> 2.4.1)
       racc
     plist (3.7.1)
     public_suffix (5.0.5)
-    racc (1.7.3)
+    racc (1.8.0)
     rainbow (3.1.1)
     rake (13.2.1)
-    regexp_parser (2.9.0)
+    regexp_parser (2.9.2)
     representable (3.2.0)
       declarative (< 0.1.0)
       trailblazer-option (>= 0.1.1, < 0.2.0)
       uber (< 0.2.0)
     retriable (3.1.2)
-    rexml (3.2.6)
+    rexml (3.2.9)
+      strscan
     rouge (2.0.7)
-    rubocop (1.63.2)
+    rubocop (1.64.1)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
@@ -193,8 +194,8 @@ GEM
       rubocop-ast (>= 1.31.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.31.2)
-      parser (>= 3.3.0.4)
+    rubocop-ast (1.31.3)
+      parser (>= 3.3.1.0)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
@@ -207,6 +208,7 @@ GEM
     simctl (1.6.10)
       CFPropertyList
       naturally
+    strscan (3.1.0)
     terminal-notifier (2.0.0)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
@@ -237,7 +239,7 @@ PLATFORMS
 DEPENDENCIES
   aws-sdk-s3 (~> 1.119)
   fastlane (~> 2.212)
-  rubocop (~> 1.42)
+  rubocop (~> 1.64)
 
 BUNDLED WITH
-   2.1.4
+   2.4.22

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .DEFAULT_GOAL := lint
 
 RELEASE_VERSION = $(shell .build/release/hostmgr --version)
-SWIFTLINT_VERSION = 0.53.0
+SWIFTLINT_VERSION=$(shell awk '/^swiftlint_version:/ {print $$2}' .swiftlint.yml)
 RUBY_VERSION = $(shell cat .ruby-version)
 
 clean:

--- a/Sources/tinys3/RequestPerformer.swift
+++ b/Sources/tinys3/RequestPerformer.swift
@@ -11,7 +11,7 @@ extension RequestPerformer {
     }
 
     func perform(_ request: URLRequest) async throws -> (Data, HTTPURLResponse) {
-        return try await withCheckedThrowingContinuation { continuation -> Void in
+        return try await withCheckedThrowingContinuation { continuation in
             let task = self.urlSession.dataTask(with: request) { data, response, networkError in
                 if let error = networkError {
                     continuation.resume(throwing: error)


### PR DESCRIPTION
While reading the code and going through the project for https://github.com/Automattic/hostmgr/pull/103, I've implemented a couple of improvements to the linting (SwiftLint + RuboCop) setup:
- Use the Linter Agent for both Swift and Ruby linting
- For running Swift locally, read the SwiftLint version from `.swiftlint.yml`
- Update `.rubocop.yml`' `TargetRubyVersion` to `3.2.2`
- Update RuboCop & SwiftLint
- Autofix a SwiftLint violation that showed up on `0.54.0`