### PR TITLE
Release `0.50.2`

### DIFF
--- a/Sources/libhostmgr/libhostmgr.swift
+++ b/Sources/libhostmgr/libhostmgr.swift
@@ -1,7 +1,7 @@
 import Foundation
 import OSLog
 
-public let hostmgrVersion = "0.50.1"
+public let hostmgrVersion = "0.50.2"
 
 public extension Logger {
     private static let subsystem = "com.automattic.hostmgr"


### PR DESCRIPTION
Preparing a new release so that we can deploy it to our hosts in time for this weekend, when the Git Mirror upload would likely fail again (see https://github.com/Automattic/hostmgr/pull/103).