### PR TITLE
Fix compilation issue with Xcode 16

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa.git",
       "state" : {
-        "revision" : "008325304ada69fa32aa7aeba967b65984f30569",
-        "version" : "8.14.2"
+        "revision" : "5575af93efb776414f243e93d6af9f6258dc539a",
+        "version" : "8.36.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
         .package(url: "https://github.com/jkmassel/kcpassword-swift.git", from: "1.0.0"),
         .package(url: "https://github.com/vapor/console-kit.git", .upToNextMajor(from: "4.9.0")),
         .package(url: "https://github.com/swhitty/FlyingFox.git", .upToNextMajor(from: "0.12.2")),
-        .package(url: "https://github.com/getsentry/sentry-cocoa.git", .upToNextMajor(from: "8.13.1")),
+        .package(url: "https://github.com/getsentry/sentry-cocoa.git", .upToNextMajor(from: "8.29.0")),
         .package(url: "https://github.com/swiftpackages/DotEnv.git", from: "3.0.0"),
     ],
     targets: [

--- a/Sources/hostmgr/GenerateCommand.swift
+++ b/Sources/hostmgr/GenerateCommand.swift
@@ -1,7 +1,7 @@
 import Foundation
 import ArgumentParser
 
-struct RunCommand: ParsableCommand {
+struct GenerateCommand: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "generate",
         abstract: "Data processing tasks",

--- a/Sources/hostmgr/HostMgrCommand.swift
+++ b/Sources/hostmgr/HostMgrCommand.swift
@@ -15,7 +15,7 @@ struct Hostmgr: AsyncParsableCommand {
             SyncCommand.self,
             InitCommand.self,
             InstallCommand.self,
-            RunCommand.self,
+            GenerateCommand.self,
             SetCommand.self,
             BenchmarkCommand.self,
             ConfigCommand.self,


### PR DESCRIPTION
## 1️⃣  Fix Xcode 16 compilation error

The project was not able to compile with Xcode 16 due to a compilation error in `SentryCrashMonitor_CPPException .cpp`.

This bug was [fixed in the Sentry-Cocoa dependency version 8.29.0](https://github.com/getsentry/sentry-cocoa/releases/tag/8.29.0), so this updates the `Package.swift` to require this version of Sentry-Cocoa as a new minimum version. After `swift package resolve`, this resolved to the current latest version (which is `8.36.0`) and compilation with Xcode 16 no longer had any issue

## 2️⃣  Fix small naming inconsistency in `struct` while at it

I noticed that the subcommand `hostmgr generate`, which was implemented in `GenerateCommand.swift` as one would expect, but the `struct` declared in that file was named `struct RunCommand` instead of being named `struct RunCommand` to match the file name and the subcommand name.

I thus took the occasion of this PR to fix this inconsistency.

_Note: The command line invocation won't be impacted by that change, as the subcommand will still be called `hostmgr generate` just as before. So there's no risk of breaking anything with that change, this is just an implementation detail._

---

## To Test

As long as CI is green we should be OK.