### PR TITLE
Mount directory for sharing keys with macOS VMs

### DIFF
--- a/Sources/hostmgr/commands/vm/VMStart.swift
+++ b/Sources/hostmgr/commands/vm/VMStart.swift
@@ -72,12 +72,14 @@ struct VMStartCommand: AsyncParsableCommand {
         }
     }
 
+    // Those paths are auto-mounted in the VM in the `/Volumes/My Shared Files/` path
+    // See https://developer.apple.com/documentation/virtualization/vzvirtiofilesystemdeviceconfiguration
+    // See Sources/libhostmgr/VM/LaunchConfiguration.swift#L69-L82
     var sharedPaths: [LaunchConfiguration.SharedPath] {
         get throws {
             var paths: [LaunchConfiguration.SharedPath] = []
 
-            if try FileManager.default.directoryExists(at: Paths.gitMirrorStorageDirectory)
-                && self.withGitMirrors == true {
+            if self.withGitMirrors && try FileManager.default.directoryExists(at: Paths.gitMirrorStorageDirectory) {
                 paths.append(LaunchConfiguration.SharedPath(source: Paths.gitMirrorStorageDirectory, readOnly: true))
             }
 

--- a/Sources/hostmgr/commands/vm/VMStart.swift
+++ b/Sources/hostmgr/commands/vm/VMStart.swift
@@ -74,17 +74,18 @@ struct VMStartCommand: AsyncParsableCommand {
 
     var sharedPaths: [LaunchConfiguration.SharedPath] {
         get throws {
-            guard try FileManager.default.directoryExists(at: Paths.gitMirrorStorageDirectory) else {
-                return []
+            var paths: [LaunchConfiguration.SharedPath] = []
+
+            if try FileManager.default.directoryExists(at: Paths.gitMirrorStorageDirectory)
+                && self.withGitMirrors == true {
+                paths.append(LaunchConfiguration.SharedPath(source: Paths.gitMirrorStorageDirectory, readOnly: true))
             }
 
-            guard self.withGitMirrors == true else {
-                return []
+            if try FileManager.default.directoryExists(at: Paths.botUserSshKeyDirectory) {
+                paths.append(LaunchConfiguration.SharedPath(source: Paths.botUserSshKeyDirectory, readOnly: true))
             }
 
-            return [
-                LaunchConfiguration.SharedPath(source: Paths.gitMirrorStorageDirectory, readOnly: true)
-            ]
+            return paths
         }
     }
 }

--- a/Sources/hostmgr/commands/vm/VMStart.swift
+++ b/Sources/hostmgr/commands/vm/VMStart.swift
@@ -19,6 +19,9 @@ struct VMStartCommand: AsyncParsableCommand {
     @Flag(help: "Mount the system git mirrors directory into the virtual machine on startup?")
     var withGitMirrors: Bool = false
 
+    @Flag(help: "Mount the directory with shared credentials into the virtual machine on startup?")
+    var withCommonCredentials: Bool = false
+
     @Flag(help: "Wait indefinitely for the SSH server to become available (useful when provisioning a new image")
     var waitForever: Bool = false
 
@@ -33,6 +36,7 @@ struct VMStartCommand: AsyncParsableCommand {
         case name
         case handle
         case withGitMirrors
+        case withCommonCredentials
         case waitForever
         case persistent
         case skipNetworkChecks
@@ -79,12 +83,16 @@ struct VMStartCommand: AsyncParsableCommand {
         get throws {
             var paths: [LaunchConfiguration.SharedPath] = []
 
-            if self.withGitMirrors && try FileManager.default.directoryExists(at: Paths.gitMirrorStorageDirectory) {
-                paths.append(LaunchConfiguration.SharedPath(source: Paths.gitMirrorStorageDirectory, readOnly: true))
+            if self.withGitMirrors {
+                if try FileManager.default.directoryExists(at: Paths.gitMirrorStorageDirectory) {
+                    paths.append(LaunchConfiguration.SharedPath(source: Paths.gitMirrorStorageDirectory, readOnly: true))
+                }
             }
 
-            if try FileManager.default.directoryExists(at: Paths.commonCredentialsDirectory) {
-                paths.append(LaunchConfiguration.SharedPath(source: Paths.commonCredentialsDirectory, readOnly: true))
+            if self.withCommonCredentials {
+                if try FileManager.default.directoryExists(at: Paths.commonCredentialsDirectory) {
+                    paths.append(LaunchConfiguration.SharedPath(source: Paths.commonCredentialsDirectory, readOnly: true))
+                }
             }
 
             return paths

--- a/Sources/hostmgr/commands/vm/VMStart.swift
+++ b/Sources/hostmgr/commands/vm/VMStart.swift
@@ -85,13 +85,17 @@ struct VMStartCommand: AsyncParsableCommand {
 
             if self.withGitMirrors {
                 if try FileManager.default.directoryExists(at: Paths.gitMirrorStorageDirectory) {
-                    paths.append(LaunchConfiguration.SharedPath(source: Paths.gitMirrorStorageDirectory, readOnly: true))
+                    paths.append(
+                        LaunchConfiguration.SharedPath(source: Paths.gitMirrorStorageDirectory, readOnly: true)
+                    )
                 }
             }
 
             if self.withCommonCredentials {
                 if try FileManager.default.directoryExists(at: Paths.commonCredentialsDirectory) {
-                    paths.append(LaunchConfiguration.SharedPath(source: Paths.commonCredentialsDirectory, readOnly: true))
+                    paths.append(
+                        LaunchConfiguration.SharedPath(source: Paths.commonCredentialsDirectory, readOnly: true)
+                    )
                 }
             }
 

--- a/Sources/hostmgr/commands/vm/VMStart.swift
+++ b/Sources/hostmgr/commands/vm/VMStart.swift
@@ -81,8 +81,8 @@ struct VMStartCommand: AsyncParsableCommand {
                 paths.append(LaunchConfiguration.SharedPath(source: Paths.gitMirrorStorageDirectory, readOnly: true))
             }
 
-            if try FileManager.default.directoryExists(at: Paths.botUserSshKeyDirectory) {
-                paths.append(LaunchConfiguration.SharedPath(source: Paths.botUserSshKeyDirectory, readOnly: true))
+            if try FileManager.default.directoryExists(at: Paths.commonCredentialsDirectory) {
+                paths.append(LaunchConfiguration.SharedPath(source: Paths.commonCredentialsDirectory, readOnly: true))
             }
 
             return paths

--- a/Sources/libhostmgr/Model/Paths.swift
+++ b/Sources/libhostmgr/Model/Paths.swift
@@ -44,6 +44,10 @@ public extension Paths {
         storageRoot.appendingPathComponent("git-mirrors", isDirectory: true)
     }()
 
+    static let botUserSshKeyDirectory: URL = {
+        storageRoot.appendingPathComponent("bot-user-ssh-key", isDirectory: true)
+    }()
+
     static let restoreImageDirectory: URL = {
         storageRoot.appendingPathComponent("restore-images", isDirectory: true)
     }()

--- a/Sources/libhostmgr/Model/Paths.swift
+++ b/Sources/libhostmgr/Model/Paths.swift
@@ -44,8 +44,8 @@ public extension Paths {
         storageRoot.appendingPathComponent("git-mirrors", isDirectory: true)
     }()
 
-    static let botUserSshKeyDirectory: URL = {
-        storageRoot.appendingPathComponent("bot-user-ssh-key", isDirectory: true)
+    static let commonCredentialsDirectory: URL = {
+        storageRoot.appendingPathComponent("common-credentials", isDirectory: true)
     }()
 
     static let restoreImageDirectory: URL = {

--- a/Sources/libhostmgr/libhostmgr.swift
+++ b/Sources/libhostmgr/libhostmgr.swift
@@ -1,7 +1,7 @@
 import Foundation
 import OSLog
 
-public let hostmgrVersion = "0.50.2"
+public let hostmgrVersion = "0.51.0"
 
 public extension Logger {
     private static let subsystem = "com.automattic.hostmgr"


### PR DESCRIPTION
This PR adds `/opt/ci/common-credentials` to the directories that are shared with macOS VMs, so that we can share SSH keys during runtime.

Related PR: https://github.com/Automattic/buildkite-ci/pull/531
Related issue: https://github.com/Automattic/apps-infra-plans/issues/39