### PR TITLE
Update default VM size from 92 GB to 120 GB

### DIFF
--- a/Sources/hostmgr/commands/vm/VMCreate.swift
+++ b/Sources/hostmgr/commands/vm/VMCreate.swift
@@ -18,7 +18,7 @@ struct VMCreateCommand: AsyncParsableCommand {
     var quiet: Bool = false
 
     @Option(help: "The disk size of machine that should be created, in GB")
-    var diskSize: Int = 92
+    var diskSize: Int = 120
 
     private enum CodingKeys: String, CodingKey {
         case name


### PR DESCRIPTION
Title mostly says it 🙂 . We've begun running into "out of space" failures in the latest VMs due to the 16.* VMs only having 92 GBs of space instead of the 120 GB we started using with the later versions of Xcode 15. By changing the default in `hostmgr`, we won't have to remember to manually change the disk size for future VMs. 