### PR TITLE
[Tooling] Update CI image from `xcode-16.1` to `xcode-16.1-v4`

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,7 +4,7 @@ common_params:
     - automattic/a8c-ci-toolkit#3.7.1
   # Common environment values to use with the `env` key.
   env: &common_env
-    IMAGE_ID: xcode-16.1
+    IMAGE_ID: xcode-16.1-v4
 
 # This is the default pipeline – it will build and test the app
 steps:


### PR DESCRIPTION
## What it does
This updates the CI image from `xcode-16.1` to `xcode-16.1.v4`. The original 16.1 image only had 92GB of space. The v4 image was upgraded to use 120GB instead. 

### How to test
Good to go as long as CI is green.
