### PR TITLE
Update `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,15 @@ A suite of tools for managing macOS virtual machines using Apple's Virtualizatio
 
 ## Overview
 
-`hostmgr` is an internal tool developed by Automattic to manage macOS VMs for CI/CD purposes. It facilitates managing multiple combinations of macOS versions, Xcode installations and tooling using a single physical machine.
+`hostmgr` is an internal tool developed by Automattic to manage macOS VMs for CI/CD purposes.
+It facilitates managing multiple combinations of macOS versions, Xcode installations and tooling on a single physical machine (typically a CI host).
 
-While primarily designed for Automattic's specific CI infrastructure, the codebase can serve as a practical reference implementation in Swift of:
+> [!IMPORTANT]
+> This tool is designed for Automattic's specific CI infrastructure, and as such have some assumptions about our CI infra and tools hardcoded into its implementation (e.g. our use of S3 to store VM templates, our use of Buildkite for our CI/CD…)
+>
+> As such, while developed in the open, this tool is not really intended to be used by other as-is, and we don't plan to address issues related to the use of this tool outside of the context of Automattic's CI infrastructure.
+
+That being said, feel free to open PRs to suggest improvements or fix issues, or just use the codebase as an inspiration and practical reference for a Swift implementation of:
 
 - Working with Apple's Virtualization framework
 - Managing macOS VMs and their lifecycle programmatically

--- a/README.md
+++ b/README.md
@@ -1,15 +1,33 @@
 # hostmgr
 
-## What is it?
+A suite of tools for managing macOS virtual machines using Apple's Virtualization framework.
 
-This tool suite is used to create and manage VMs on our Buildkite CI Mac hosts:
+## Overview
 
- - `hostmgr` is a command-line tool to:
-    - Create, package and publish VMs… (when we prepare new VMs for new macOS or Xcode versions)
-    - List installed VMs, fetch VMs, start and stop VMs… (when running this tool on our CI hosts, to boot VMs and run Buildkite jobs in them)
- - `hostmgr-helper` is a helper tool used to display the VM's GUI in a window on the host machine.
-    - This helper shows up as a Menu Bar item in your Mac, listing running VMs and allowing you to VNC to them, show their UI in a window, or stop them.
-    - It is especially useful when [creating new OS templates for VMs](https://github.com/Automattic/buildkite-ci/blob/trunk/src/agents/macos-vms/README.md), to go through the macOS setup wizard via the GUI when configuring the template VM.
+`hostmgr` is an internal tool developed by Automattic to manage macOS VMs for CI/CD purposes. It facilitates managing multiple combinations of macOS versions, Xcode installations and tooling using a single physical machine.
+
+While primarily designed for Automattic's specific CI infrastructure, the codebase can serve as a practical reference implementation in Swift of:
+
+- Working with Apple's Virtualization framework
+- Managing macOS VMs and their lifecycle programmatically
+- Integration and publishing of VM images in AWS S3
+
+The suite consists of two main components:
+
+### `hostmgr` CLI
+A command-line tool that provides capabilities for:
+- Creating, packaging, and publishing VMs to S3
+- Managing VM lifecycle (start, stop, list)
+- Preparing 
+- Integration with CI systems (specifically Buildkite in our case)
+
+### `hostmgr-helper`
+A macOS menu bar application that:
+- Provides GUI access to running VMs
+- Enables VNC connections to VMs
+- Displays VM status and controls
+- Facilitates initial VM setup through graphical interface
+  - We use it to [create new OS templates for VMs](https://github.com/Automattic/buildkite-ci/blob/trunk/src/agents/macos-vms/README.md), to go through the macOS setup wizard via the GUI when configuring the template VM.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ A macOS menu bar application that:
 - Enables VNC connections to VMs
 - Displays VM status and controls
 - Facilitates initial VM setup through graphical interface
-  - We use it to [create new OS templates for VMs](https://github.com/Automattic/buildkite-ci/blob/trunk/src/agents/macos-vms/README.md), to go through the macOS setup wizard via the GUI when configuring the template VM.
+  - We use it to [create new OS templates for VMs](https://github.com/Automattic/buildkite-ci/blob/trunk/src/agents/macos-vms/README.md) _(Automattic internal link)_, to go through the macOS setup wizard via the GUI when configuring the template VM.
 
 ## Installation
 
-Those tools are installed in our macOS CI hosts when those are deployed, using the [Ansible playbook](https://github.com/Automattic/buildkite-ci/blob/trunk/src/agents/macos-hosts/tasks/install-hostmgr.yml)
+Those tools are installed in our macOS CI hosts when those are deployed, using the [Ansible playbook](https://github.com/Automattic/buildkite-ci/blob/trunk/src/agents/macos-hosts/tasks/install-hostmgr.yml) _(Automattic internal link)_
 
 When you need to install those tools on your local machine—typically to create new OS templates or Xcode VMs—follow the below instructions:
 
@@ -45,7 +45,7 @@ _(We can potentially automate this step, but for now this is still manual)_
    - Either by right-clicking the executable in the Finder, selecting "Open" in the context menu, and click "Open" button.
    - Or by running `xattr -d com.apple.quarantine /opt/ci/bin/hostmgr /opt/ci/bin/hostmgr-helper`.
 1. Add `/opt/ci/bin` to your PATH so that the VM tools will be able to use `hostmgr` and `hostmgr-helper`
-1. Create a config file in `/opt/ci/hostmgr.json`. You can copy [the file we use to provision our macOS CI hosts](https://github.com/Automattic/buildkite-ci/blob/trunk/src/agents/macos-hosts/resources/hostmgr.json) directly there.
+1. Create a config file in `/opt/ci/hostmgr.json`. You can copy [the file we use to provision our macOS CI hosts](https://github.com/Automattic/buildkite-ci/blob/trunk/src/agents/macos-hosts/resources/hostmgr.json) _(Automattic internal link)_ directly there.
 1. Open a Terminal and run `hostmgr-helper` to launch the "hostmgr-helper" macOS app, which needs to be running during building VM images.
 
 ## Release


### PR DESCRIPTION
References:
- https://github.com/Automattic/hostmgr/issues/101
- p1733916640605019-slack-C02KLTL3MKM

This PR updates the `README.md` to make it clearer that this is an internal tool, but it can still be useful for folks outside Automattic to explore the code for references in using, for example, Apple's Virtualization framework, and use the code as an inspiration for building similar tools.