### PR TITLE
Improve slot error handling

### DIFF
--- a/Sources/hostmgr-helper/VirtualMachineSlot.swift
+++ b/Sources/hostmgr-helper/VirtualMachineSlot.swift
@@ -74,6 +74,7 @@ class VirtualMachineSlot: NSObject, ObservableObject {
             } catch {
                 Logger.helper.error("Failed to remove VM file: \(error)")
             }
+            self.managedVirtualMachine = nil
             self.status = .crashed(error)
             throw error
         }

--- a/Sources/hostmgr-helper/VirtualMachineSlot.swift
+++ b/Sources/hostmgr-helper/VirtualMachineSlot.swift
@@ -87,7 +87,13 @@ class VirtualMachineSlot: NSObject, ObservableObject {
         default:
             break
         }
-        try await managedVirtualMachine?.machine.stop()
+        if let machine = managedVirtualMachine?.machine, machine.canStop {
+            do {
+                try await machine.stop()
+            } catch {
+                Logger.helper.error("Failed to stop VM: \(error)")
+            }
+        }
         await resetSlot()
     }
 


### PR DESCRIPTION
- Continues resetting the slot even if the VM fails to stop, but logs the error.
- Sets `self.managedVirtualMachine` to `nil` to get the slot back to a reset state.