### PR TITLE
Update `vm list` help text

### DIFF
--- a/Sources/hostmgr/commands/vm/VMList.swift
+++ b/Sources/hostmgr/commands/vm/VMList.swift
@@ -5,7 +5,7 @@ import libhostmgr
 struct VMListCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "list",
-        abstract: "List VM images that exist on disk on the local machine"
+        abstract: "List VM images with information about location, filename, packaging state, and size."
     )
 
     enum Location: String, CaseIterable {


### PR DESCRIPTION
The command output has much more than information about locally available VMs. In particular, it lists all available VMs, remote or local.

Example:

```
Location  | Filename                   | State       |     Size
--------- | -------------------------- | ----------- | --------
🌐 Remote | macos-14.3                 | 📦 Packaged | 15.34 GB
🌐 Remote | macos-14.5                 | 📦 Packaged | 15.40 GB
🌐 Remote | macos-14.6.1               | 📦 Packaged | 15.52 GB
🌐 Remote | macos-14.7.1               | 📦 Packaged | 24.84 GB
...
```

This update makes the abstract reflect the current command output.