### PR TITLE
Refactor VirtualMachineSlot to reduce races

### DIFF
--- a/Sources/hostmgr-helper/ManagedVirtualMachine.swift
+++ b/Sources/hostmgr-helper/ManagedVirtualMachine.swift
@@ -41,7 +41,7 @@ class ManagedVirtualMachine {
                 }
             } catch {
                 Logger.helper.error("Startup of \(handle) failed: \(error)")
-                await cleanUp()
+                await stop()
                 throw error
             }
         }

--- a/Sources/hostmgr-helper/ManagedVirtualMachine.swift
+++ b/Sources/hostmgr-helper/ManagedVirtualMachine.swift
@@ -66,8 +66,8 @@ class ManagedVirtualMachine {
     }
 
     private func cleanUp() async {
-        machine = nil
         Logger.helper.log("Attempting cleanup of VM \(handle)")
+        machine = nil
         do {
             try await vmManager.removeVM(name: handle)
         } catch {

--- a/Sources/hostmgr-helper/ManagedVirtualMachine.swift
+++ b/Sources/hostmgr-helper/ManagedVirtualMachine.swift
@@ -23,7 +23,7 @@ class ManagedVirtualMachine {
     func start() -> Task<Void, Error> {
         Task {
             do {
-                Logger.helper.log("Start task started for \(handle).")
+                Logger.helper.log("Start task started for VM \(handle).")
                 let newMachine = try await config.setupVirtualMachine()
                 self.machine = newMachine
                 try await newMachine.start()
@@ -31,12 +31,12 @@ class ManagedVirtualMachine {
                 if config.waitForNetworking {
                     self.ip = try await vmManager.ipAddress(forVmWithName: handle)
                     Logger.helper.log(
-                        "Startup of \(handle) complete – IP Address: \(ip.debugDescription)"
+                        "Startup of VM \(handle) complete – IP Address: \(ip.debugDescription)"
                     )
                 } else {
                     self.ip = .any
                     Logger.helper.log(
-                        "Startup of \(handle) in progress – skipped waiting for IP address per launch configuration"
+                        "Startup of VM \(handle) in progress – skipped waiting for IP address per launch configuration"
                     )
                 }
             } catch {
@@ -48,7 +48,7 @@ class ManagedVirtualMachine {
     }
 
     func stop() async {
-        Logger.helper.log("Stop called for \(handle).")
+        Logger.helper.log("Stop called for VM \(handle).")
         if let machine {
             /// Don't send events to delegate anymore
             machine.delegate = nil
@@ -66,12 +66,12 @@ class ManagedVirtualMachine {
     }
 
     private func cleanUp() async {
-        Logger.helper.log("Attempting cleanup of \(handle)")
         machine = nil
+        Logger.helper.log("Attempting cleanup of VM \(handle)")
         do {
             try await vmManager.removeVM(name: handle)
         } catch {
-            Logger.helper.error("Failed to remove VM file for \(handle): \(error)")
+            Logger.helper.error("Failed to remove files for VM \(handle): \(error)")
         }
     }
 }

--- a/Sources/hostmgr-helper/ManagedVirtualMachine.swift
+++ b/Sources/hostmgr-helper/ManagedVirtualMachine.swift
@@ -67,6 +67,7 @@ class ManagedVirtualMachine {
 
     private func cleanUp() async {
         Logger.helper.log("Attempting cleanup of \(handle)")
+        machine = nil
         do {
             try await vmManager.removeVM(name: handle)
         } catch {

--- a/Sources/hostmgr-helper/ManagedVirtualMachine.swift
+++ b/Sources/hostmgr-helper/ManagedVirtualMachine.swift
@@ -7,8 +7,21 @@ import libhostmgr
 @MainActor
 class ManagedVirtualMachine {
     private let vmManager = VMManager()
+    private var state: State = .stopped
     private(set) var machine: VZVirtualMachine?
     private(set) var ip: IPv4Address?
+
+    enum Errors: Error {
+        /// the machine was not in a state to start
+        case vmStartFailed
+    }
+
+    enum State {
+        case starting
+        case running
+        case stopping
+        case stopped
+    }
 
     let config: LaunchConfiguration
 
@@ -20,8 +33,15 @@ class ManagedVirtualMachine {
         self.config = config
     }
 
+    /// Creates and starts the underlying virtual machine. If anything fails in the process
+    /// of starting, state is reset and the VM files are cleaned.
     func start() async throws {
-        Logger.helper.log("Start called for VM \(handle).")
+        Logger.helper.log("Start called for VM \(handle)")
+        guard state == .stopped else {
+            throw Errors.vmStartFailed
+        }
+        self.state = .starting
+
         do {
             let newMachine = try await config.setupVirtualMachine()
             self.machine = newMachine
@@ -38,6 +58,7 @@ class ManagedVirtualMachine {
                     "Startup of VM \(handle) in progress – skipped waiting for IP address per launch configuration"
                 )
             }
+            self.state = .running
         } catch {
             Logger.helper.error("Startup of \(handle) failed: \(error)")
             await stop()
@@ -45,14 +66,24 @@ class ManagedVirtualMachine {
         }
     }
 
+    /// Stops a running machine and cleans up the bundle on the filesystem.
     func stop() async {
         Logger.helper.log("Stop called for VM \(handle).")
+        switch state {
+        case .starting, .running:
+            state = .stopping
+        case .stopping, .stopped:
+            Logger.helper.error(
+                "Stop called for VM \(handle) while already in state \(state), ignoring"
+            )
+            return
+        }
         if let machine {
             /// Don't send events to delegate anymore
             machine.delegate = nil
             if machine.canStop {
                 do {
-                    Logger.helper.debug("Attempting to stop VM \(handle).")
+                    Logger.helper.debug("Attempting to stop VM \(handle)")
                     /// Note: It's suspected that this call may hang under certain conditions.
                     try await machine.stop()
                 } catch {
@@ -63,6 +94,7 @@ class ManagedVirtualMachine {
         await cleanUp()
     }
 
+    /// Destroys the VM and cleans up its files.
     private func cleanUp() async {
         Logger.helper.log("Attempting cleanup of VM \(handle)")
         machine = nil
@@ -71,5 +103,6 @@ class ManagedVirtualMachine {
         } catch {
             Logger.helper.error("Failed to remove files for VM \(handle): \(error)")
         }
+        self.state = .stopped
     }
 }

--- a/Sources/hostmgr-helper/ManagedVirtualMachine.swift
+++ b/Sources/hostmgr-helper/ManagedVirtualMachine.swift
@@ -1,5 +1,5 @@
 import Foundation
-@preconcurrency import Virtualization
+import Virtualization
 import OSLog
 import Network
 import libhostmgr

--- a/Sources/hostmgr-helper/ManagedVirtualMachine.swift
+++ b/Sources/hostmgr-helper/ManagedVirtualMachine.swift
@@ -20,30 +20,28 @@ class ManagedVirtualMachine {
         self.config = config
     }
 
-    func start() -> Task<Void, Error> {
-        Task {
-            do {
-                Logger.helper.log("Start task started for VM \(handle).")
-                let newMachine = try await config.setupVirtualMachine()
-                self.machine = newMachine
-                try await newMachine.start()
+    func start() async throws {
+        Logger.helper.log("Start called for VM \(handle).")
+        do {
+            let newMachine = try await config.setupVirtualMachine()
+            self.machine = newMachine
+            try await newMachine.start()
 
-                if config.waitForNetworking {
-                    self.ip = try await vmManager.ipAddress(forVmWithName: handle)
-                    Logger.helper.log(
-                        "Startup of VM \(handle) complete – IP Address: \(ip.debugDescription)"
-                    )
-                } else {
-                    self.ip = .any
-                    Logger.helper.log(
-                        "Startup of VM \(handle) in progress – skipped waiting for IP address per launch configuration"
-                    )
-                }
-            } catch {
-                Logger.helper.error("Startup of \(handle) failed: \(error)")
-                await stop()
-                throw error
+            if config.waitForNetworking {
+                self.ip = try await vmManager.ipAddress(forVmWithName: handle)
+                Logger.helper.log(
+                    "Startup of VM \(handle) complete – IP Address: \(ip.debugDescription)"
+                )
+            } else {
+                self.ip = .any
+                Logger.helper.log(
+                    "Startup of VM \(handle) in progress – skipped waiting for IP address per launch configuration"
+                )
             }
+        } catch {
+            Logger.helper.error("Startup of \(handle) failed: \(error)")
+            await stop()
+            throw error
         }
     }
 

--- a/Sources/hostmgr-helper/ManagedVirtualMachine.swift
+++ b/Sources/hostmgr-helper/ManagedVirtualMachine.swift
@@ -1,0 +1,71 @@
+import Foundation
+@preconcurrency import Virtualization
+import OSLog
+import Network
+import libhostmgr
+
+@MainActor
+class ManagedVirtualMachine {
+    private let vmManager = VMManager()
+    private(set) var machine: VZVirtualMachine?
+    private(set) var ip: IPv4Address?
+
+    let config: LaunchConfiguration
+
+    var handle: String {
+        config.handle
+    }
+
+    init(config: LaunchConfiguration) {
+        self.config = config
+    }
+
+    func start() -> Task<Void, Error> {
+        Task {
+            do {
+                Logger.helper.log("Start task started for \(handle).")
+                let newMachine = try await config.setupVirtualMachine()
+                self.machine = newMachine
+                try await newMachine.start()
+
+                if config.waitForNetworking {
+                    self.ip = try await vmManager.ipAddress(forVmWithName: handle)
+                    Logger.helper.log("Startup of \(handle) complete – IP Address: \(ip.debugDescription)")
+                } else {
+                    Logger.helper.log("Startup of \(handle) in progress – skipped waiting for IP address per launch configuration")
+                    self.ip = .any
+                }
+            } catch {
+                await cleanUp()
+                throw error
+            }
+        }
+    }
+
+    func stop() async {
+        Logger.helper.log("Stop called for \(handle).")
+        if let machine {
+            /// Don't send events to delegate anymore
+            machine.delegate = nil
+            if machine.canStop {
+                do {
+                    Logger.helper.debug("Attempting to stop VM \(handle).")
+                    /// Note: It's suspected that this call may hang under certain conditions.
+                    try await machine.stop()
+                } catch {
+                    Logger.helper.error("Failed to stop VM \(handle): \(error)")
+                }
+            }
+        }
+        await cleanUp()
+    }
+
+    private func cleanUp() async {
+        Logger.helper.log("Attempting cleanup of \(handle)")
+        do {
+            try await vmManager.removeVM(name: handle)
+        } catch {
+            Logger.helper.error("Failed to remove VM file for \(handle): \(error)")
+        }
+    }
+}

--- a/Sources/hostmgr-helper/ManagedVirtualMachine.swift
+++ b/Sources/hostmgr-helper/ManagedVirtualMachine.swift
@@ -30,9 +30,13 @@ class ManagedVirtualMachine {
 
                 if config.waitForNetworking {
                     self.ip = try await vmManager.ipAddress(forVmWithName: handle)
-                    Logger.helper.log("Startup of \(handle) complete – IP Address: \(ip.debugDescription)")
+                    Logger.helper.log(
+                        "Startup of \(handle) complete – IP Address: \(ip.debugDescription)"
+                    )
                 } else {
-                    Logger.helper.log("Startup of \(handle) in progress – skipped waiting for IP address per launch configuration")
+                    Logger.helper.log(
+                        "Startup of \(handle) in progress – skipped waiting for IP address per launch configuration"
+                    )
                     self.ip = .any
                 }
             } catch {

--- a/Sources/hostmgr-helper/ManagedVirtualMachine.swift
+++ b/Sources/hostmgr-helper/ManagedVirtualMachine.swift
@@ -34,12 +34,13 @@ class ManagedVirtualMachine {
                         "Startup of \(handle) complete – IP Address: \(ip.debugDescription)"
                     )
                 } else {
+                    self.ip = .any
                     Logger.helper.log(
                         "Startup of \(handle) in progress – skipped waiting for IP address per launch configuration"
                     )
-                    self.ip = .any
                 }
             } catch {
+                Logger.helper.error("Startup of \(handle) failed: \(error)")
                 await cleanUp()
                 throw error
             }

--- a/Sources/hostmgr-helper/VM List/States/RunningVMListItem.swift
+++ b/Sources/hostmgr-helper/VM List/States/RunningVMListItem.swift
@@ -29,7 +29,7 @@ struct RunningVMListItem: View {
 
     func shutdown() {
         Task {
-            try await slot.stopVirtualMachine()
+            try await slot.stop()
         }
     }
 

--- a/Sources/hostmgr-helper/VM List/VMListItem.swift
+++ b/Sources/hostmgr-helper/VM List/VMListItem.swift
@@ -8,15 +8,15 @@ struct VMListItem: View {
     var body: some View {
         switch slot.status {
         case .empty: EmptyVMListItem(slot: slot)
-        case .starting(let launchConfiguration):
+        case .starting(_, let mvm):
             PendingVMListItem(
-                launchConfiguration: launchConfiguration,
+                launchConfiguration: mvm.config,
                 slot: slot
             )
-        case .running(let launchConfiguration, let ipAddress):
+        case .running(let mvm):
             RunningVMListItem(
-                launchConfiguration: launchConfiguration,
-                ipAddress: ipAddress,
+                launchConfiguration: mvm.config,
+                ipAddress: mvm.ip ?? .any,
                 slot: slot
             )
         case .stopping:

--- a/Sources/hostmgr-helper/VM List/VMListItem.swift
+++ b/Sources/hostmgr-helper/VM List/VMListItem.swift
@@ -8,7 +8,7 @@ struct VMListItem: View {
     var body: some View {
         switch slot.status {
         case .empty: EmptyVMListItem(slot: slot)
-        case .starting(_, let mvm):
+        case .starting(let mvm, _):
             PendingVMListItem(
                 launchConfiguration: mvm.config,
                 slot: slot

--- a/Sources/hostmgr-helper/VMHost.swift
+++ b/Sources/hostmgr-helper/VMHost.swift
@@ -45,11 +45,11 @@ extension VMHost: HostmgrServerDelegate {
         Logger.helper.log("Received stop request for \(handle)")
 
         if self.primaryVMSlot.isConfiguredForHandle(handle) {
-            try await primaryVMSlot.stopVirtualMachine()
+            try await primaryVMSlot.stop()
         }
 
         if self.secondaryVMSlot.isConfiguredForHandle(handle) {
-            try await secondaryVMSlot.stopVirtualMachine()
+            try await secondaryVMSlot.stop()
         }
     }
 
@@ -58,8 +58,8 @@ extension VMHost: HostmgrServerDelegate {
 
         repeat {
             do {
-                try await self.primaryVMSlot.stopVirtualMachine()
-                try await self.secondaryVMSlot.stopVirtualMachine()
+                try await self.primaryVMSlot.stop()
+                try await self.secondaryVMSlot.stop()
                 return
             } catch {
                 try await Task.sleep(for: .seconds(1))

--- a/Sources/hostmgr-helper/VMWindow.swift
+++ b/Sources/hostmgr-helper/VMWindow.swift
@@ -13,7 +13,7 @@ struct VMWindowContent: View {
         switch vmSlot.status {
         case .empty:  Text("VM not running")
         case .starting: ProgressView()
-        case .running: VirtualMachineDisplayView(virtualMachine: vmSlot.managedVirtualMachine?.machine)
+        case .running(let mvm): VirtualMachineDisplayView(virtualMachine: mvm.machine)
         .onAppear {
             NSApp.setActivationPolicy(.regular)
             NSApp.activate(ignoringOtherApps: true)

--- a/Sources/hostmgr-helper/VirtualMachineSlot.swift
+++ b/Sources/hostmgr-helper/VirtualMachineSlot.swift
@@ -50,7 +50,7 @@ class VirtualMachineSlot: NSObject, ObservableObject {
 
         do {
             let mvm = ManagedVirtualMachine(config: launchConfiguration)
-            let startTask = mvm.start()
+            let startTask = Task { try await mvm.start() }
             self.status = .starting(mvm, startTask)
 
             try await startTask.value

--- a/Sources/hostmgr-helper/VirtualMachineSlot.swift
+++ b/Sources/hostmgr-helper/VirtualMachineSlot.swift
@@ -55,6 +55,7 @@ class VirtualMachineSlot: NSObject, ObservableObject {
 
             try await startTask.value
             if startTask.isCancelled {
+                Logger.helper.debug("Start task was cancelled for \(mvm.handle)")
                 throw Errors.vmStartCancelled
             }
             mvm.machine?.delegate = self
@@ -76,15 +77,21 @@ class VirtualMachineSlot: NSObject, ObservableObject {
             status = .stopping(mvm)
             await mvm.stop()
         case .stopping, .empty, .crashed:
-            Logger.helper.debug("\(self.role.displayName) slot was asked to stop with \(status) status.")
+            Logger.helper.debug(
+                "\(self.role.displayName) slot was asked to stop with \(status) status."
+            )
             return
         }
 
         if let error {
-            Logger.helper.error("Resetting \(self.role) slot with crashed state: \(error)")
+            Logger.helper.error(
+                "Resetting \(self.role) slot with crashed state: \(error)"
+            )
             self.status = .crashed(error)
         } else {
-            Logger.helper.debug("Setting \(self.role) slot to empty state.")
+            Logger.helper.debug(
+                "Setting \(self.role) slot to empty state."
+            )
             self.status = .empty
         }
     }
@@ -98,7 +105,9 @@ class VirtualMachineSlot: NSObject, ObservableObject {
             )
             return mvm.handle == handle
         case .empty, .crashed:
-            Logger.helper.debug("\(self.role) slot had no handle configured")
+            Logger.helper.debug(
+                "\(self.role) slot had no handle configured"
+            )
             return false
         }
     }
@@ -106,9 +115,15 @@ class VirtualMachineSlot: NSObject, ObservableObject {
     @MainActor
     var isAvailable: Bool {
         switch self.status {
-        case .starting, .running, .stopping:
+        case .starting(let mvm, _), .running(let mvm), .stopping(let mvm):
+            Logger.helper.debug(
+                "\(role.displayName) slot is not available. \(mvm.handle) has status \(self.status)"
+            )
             return false
         case .empty, .crashed:
+            Logger.helper.debug(
+                "\(role.displayName) slot is available."
+            )
             return true
         }
     }
@@ -118,14 +133,14 @@ class VirtualMachineSlot: NSObject, ObservableObject {
 extension VirtualMachineSlot: VZVirtualMachineDelegate {
     /// Called when a VM is stopped gracefully
     nonisolated func guestDidStop(_ virtualMachine: VZVirtualMachine) {
-        Logger.helper.log("Virtual Machine Stopped")
+        Logger.helper.log("Virtual machine stopped")
         Task {
             try? await stop()
         }
     }
 
     nonisolated func virtualMachine(_ virtualMachine: VZVirtualMachine, didStopWithError error: Error) {
-        Logger.helper.error("Virtual Machine Crashed: \(error.localizedDescription)")
+        Logger.helper.error("Virtual machine crashed: \(error.localizedDescription)")
         Task {
             try? await stop(withError: error)
         }

--- a/Sources/hostmgr-helper/VirtualMachineSlot.swift
+++ b/Sources/hostmgr-helper/VirtualMachineSlot.swift
@@ -19,21 +19,18 @@ class VirtualMachineSlot: NSObject, ObservableObject {
 
     enum Status: Sendable {
         case empty
-        case starting(LaunchConfiguration)
-        case running(LaunchConfiguration, IPv4Address)
-        case stopping
+        case starting(Task<Void, Error>, ManagedVirtualMachine)
+        case running(ManagedVirtualMachine)
+        case stopping(ManagedVirtualMachine)
         case crashed(Error)
     }
 
-    struct ManagedVirtualMachine {
-        let machine: VZVirtualMachine
-        let config: LaunchConfiguration
+    enum Errors: Error {
+        /// the slot was asked to start a new VM when it wasn't available
+        case invalidStartState
+        /// the VM was stopped while starting
+        case vmStartCancelled
     }
-
-    private let vmManager = VMManager()
-
-    @Published
-    var managedVirtualMachine: ManagedVirtualMachine?
 
     @Published @MainActor
     var status: Status = .empty
@@ -47,35 +44,23 @@ class VirtualMachineSlot: NSObject, ObservableObject {
 
     @MainActor
     func start(launchConfiguration: LaunchConfiguration) async throws {
-
-        self.status = .starting(launchConfiguration)
+        guard isAvailable else {
+            throw Errors.invalidStartState
+        }
 
         do {
-            let virtualMachine = try await launchConfiguration.setupVirtualMachine()
-            virtualMachine.delegate = self
-            self.managedVirtualMachine = ManagedVirtualMachine(machine: virtualMachine, config: launchConfiguration)
+            let mvm = ManagedVirtualMachine(config: launchConfiguration)
+            let startTask = mvm.start()
+            self.status = .starting(startTask, mvm)
 
-            try await virtualMachine.start()
-
-            if launchConfiguration.waitForNetworking {
-                let ipAddress = try await vmManager.ipAddress(forVmWithName: launchConfiguration.handle)
-                Logger.helper.log("Startup complete – IP Address: \(ipAddress.debugDescription)")
-                self.status = .running(launchConfiguration, ipAddress)
-            } else {
-                Logger.helper.log("Startup in progress – skipped waiting for IP address per launch configuration")
-                self.status = .running(launchConfiguration, .any)
+            try await startTask.value
+            if startTask.isCancelled {
+                throw Errors.vmStartCancelled
             }
+            mvm.machine?.delegate = self
+            self.status = .running(mvm)
         } catch {
-            Logger.helper.error("Error launching VM: \(error.localizedDescription)")
-            Logger.helper.error("Attempting Cleanup of \(launchConfiguration.handle)")
-
-            do {
-                try await vmManager.removeVM(name: launchConfiguration.handle)
-            } catch {
-                Logger.helper.error("Failed to remove VM file: \(error)")
-            }
-            self.managedVirtualMachine = nil
-            self.status = .crashed(error)
+            try? await stop(withError: error)
             throw error
         }
     }
@@ -83,60 +68,48 @@ class VirtualMachineSlot: NSObject, ObservableObject {
     @MainActor
     func stop(withError error: Error? = nil) async throws {
         switch status {
-        case .starting, .running:
-            self.status = .stopping
-        default:
-            break
-        }
-        if let machine = managedVirtualMachine?.machine, machine.canStop {
-            do {
-                try await machine.stop()
-            } catch {
-                Logger.helper.error("Failed to stop VM: \(error)")
-            }
-        }
-        await resetSlot()
-    }
-
-    /// Resets the slot to a stopped status
-    ///
-    /// No need to do anything except some internal bookkeeping
-    /// - Parameter error: Error supplied if the VM crashed
-    @MainActor
-    func resetSlot(withError error: Error? = nil) async {
-        if let managedVirtualMachine {
-            do {
-                try await vmManager.removeVM(name: managedVirtualMachine.config.handle)
-            } catch {
-                Logger.helper.error("Failed to remove VM file: \(error)")
-            }
-            self.managedVirtualMachine = nil
+        case .starting(let task, let mvm):
+            status = .stopping(mvm)
+            task.cancel()
+            await mvm.stop()
+        case .running(let mvm):
+            status = .stopping(mvm)
+            await mvm.stop()
+        case .stopping, .empty, .crashed:
+            Logger.helper.debug("\(self.role.displayName) slot was asked to stop with \(status) status.")
+            return
         }
 
         if let error {
-            Logger.helper.error("Resetting slot with crashed state: \(error)")
+            Logger.helper.error("Resetting \(self.role) slot with crashed state: \(error)")
             self.status = .crashed(error)
         } else {
+            Logger.helper.debug("Setting \(self.role) slot to empty state.")
             self.status = .empty
         }
     }
 
     @MainActor
     func isConfiguredForHandle(_ handle: String) -> Bool {
-        guard let configHandle = managedVirtualMachine?.config.handle else {
+        switch status {
+        case .starting(_, let mvm), .running(let mvm), .stopping(let mvm):
+            Logger.helper.debug(
+                "Comparing \(mvm.handle) and \(handle)"
+            )
+            return mvm.handle == handle
+        case .empty, .crashed:
+            Logger.helper.debug("\(self.role) slot had no handle configured")
             return false
         }
-        Logger.helper.debug(
-            "Comparing \(configHandle) and \(handle)"
-        )
-        return configHandle == handle
     }
 
     @MainActor
     var isAvailable: Bool {
         switch self.status {
-        case .empty, .crashed: return true
-        default: return false
+        case .starting, .running, .stopping:
+            return false
+        case .empty, .crashed:
+            return true
         }
     }
 }

--- a/Sources/hostmgr-helper/VirtualMachineSlot.swift
+++ b/Sources/hostmgr-helper/VirtualMachineSlot.swift
@@ -19,7 +19,7 @@ class VirtualMachineSlot: NSObject, ObservableObject {
 
     enum Status: Sendable {
         case empty
-        case starting(Task<Void, Error>, ManagedVirtualMachine)
+        case starting(ManagedVirtualMachine, Task<Void, Error>)
         case running(ManagedVirtualMachine)
         case stopping(ManagedVirtualMachine)
         case crashed(Error)
@@ -51,7 +51,7 @@ class VirtualMachineSlot: NSObject, ObservableObject {
         do {
             let mvm = ManagedVirtualMachine(config: launchConfiguration)
             let startTask = mvm.start()
-            self.status = .starting(startTask, mvm)
+            self.status = .starting(mvm, startTask)
 
             try await startTask.value
             if startTask.isCancelled {
@@ -68,7 +68,7 @@ class VirtualMachineSlot: NSObject, ObservableObject {
     @MainActor
     func stop(withError error: Error? = nil) async throws {
         switch status {
-        case .starting(let task, let mvm):
+        case .starting(let mvm, let task):
             status = .stopping(mvm)
             task.cancel()
             await mvm.stop()
@@ -92,7 +92,7 @@ class VirtualMachineSlot: NSObject, ObservableObject {
     @MainActor
     func isConfiguredForHandle(_ handle: String) -> Bool {
         switch status {
-        case .starting(_, let mvm), .running(let mvm), .stopping(let mvm):
+        case .starting(let mvm, _), .running(let mvm), .stopping(let mvm):
             Logger.helper.debug(
                 "Comparing \(mvm.handle) and \(handle)"
             )

--- a/Sources/hostmgr-helper/VirtualMachineSlot.swift
+++ b/Sources/hostmgr-helper/VirtualMachineSlot.swift
@@ -81,7 +81,7 @@ class VirtualMachineSlot: NSObject, ObservableObject {
     }
 
     @MainActor
-    func stopVirtualMachine() async throws {
+    func stop(withError error: Error? = nil) async throws {
         switch status {
         case .starting, .running:
             self.status = .stopping
@@ -147,14 +147,14 @@ extension VirtualMachineSlot: VZVirtualMachineDelegate {
     nonisolated func guestDidStop(_ virtualMachine: VZVirtualMachine) {
         Logger.helper.log("Virtual Machine Stopped")
         Task {
-            await resetSlot()
+            try? await stop()
         }
     }
 
     nonisolated func virtualMachine(_ virtualMachine: VZVirtualMachine, didStopWithError error: Error) {
         Logger.helper.error("Virtual Machine Crashed: \(error.localizedDescription)")
         Task {
-            await resetSlot(withError: error)
+            try? await stop(withError: error)
         }
     }
 
@@ -165,7 +165,7 @@ extension VirtualMachineSlot: VZVirtualMachineDelegate {
     ) {
         Logger.helper.error("Network attachment was disconnected: \(error.localizedDescription)")
         Task {
-            try await stopVirtualMachine()
+            try? await stop()
         }
     }
 }

--- a/Sources/hostmgr-helper/VirtualMachineSlot.swift
+++ b/Sources/hostmgr-helper/VirtualMachineSlot.swift
@@ -1,5 +1,5 @@
 import Foundation
-@preconcurrency import Virtualization
+import Virtualization
 import SwiftUI
 import OSLog
 import Network

--- a/Sources/libhostmgr/Platforms/VMManager.swift
+++ b/Sources/libhostmgr/Platforms/VMManager.swift
@@ -14,6 +14,11 @@ public struct VMManager {
         self.console = console ?? Console()
     }
 
+    enum Errors: Error {
+        // trying to establish an SSH connection timed out
+        case sshConnectionTimeout
+    }
+
     /// Start a VM
     ///
     public func startVM(configuration: LaunchConfiguration) async throws {
@@ -221,7 +226,7 @@ extension VMManager {
                 case .failed(let error):
                     continuation.resume(throwing: error)
                 case .cancelled:
-                    continuation.resume(throwing: CocoaError(.serviceRequestTimedOut))
+                    continuation.resume(throwing: Errors.sshConnectionTimeout)
                 default:
                     break
                 }

--- a/Sources/libhostmgr/Platforms/VMManager.swift
+++ b/Sources/libhostmgr/Platforms/VMManager.swift
@@ -15,7 +15,7 @@ public struct VMManager {
     }
 
     enum Errors: Error {
-        // trying to establish an SSH connection timed out
+        /// Trying to establish an SSH connection timed out
         case sshConnectionTimeout
     }
 


### PR DESCRIPTION
## Attempts to fix
- #124
- #84

**Note:** This PR _does not_ attempt to fix an issue we're seeing with `hostmgr vm stop [handle]` becoming unresponsive. #126 covers that.

## Description
- Turns the VM start call (start the VM and fetch an IP) into a Swift `Task` so that it has the option to be cancelled. This resolves an issue where a VM could've been stopped externally and the async start sequence returned to set the slot to a `.running` state.
- Removes state from `VirtualMachineSlot` by enforcing tighter coupling with the `Status` enum.
- Moves `ManagedVirtualMachine` to its own file to better decouple the lifecycle of a VM from a slot's state.
- Makes the error thrown when the SSH connection times out: `Error: sshConnectionTimeout` rather than `Error: The operation couldn't be completed. (Cocoa error 66562.)`

## Testing

### Steps from https://github.com/Automattic/hostmgr/pull/118

#### Prereqs

For each test confirm:
1. The bundle no longer exists in `/opt/ci/working-vm-images`
2. The VM no longer appears in the list when running `hostmgr vm list`
3. The VM no longer appears in the slot UI in the `hostmgr-helper` menu bar app
4. The `Virtual Machine Service for hostmgr-helper` process is killed by the OS
5. When the occupied slot count is less than 2, a new VM can start and the `Unable to launch more VMs – maximum reached` isn't shown.

#### Tests

1. Stop a VM by selecting the "Stop" button in the `hostmgr-helper` menu bar app
2. Stop a VM by running `hostmgr vm stop [handle]` in the command line
3. Stop a VM by killing the process using Activity Monitor (or the `kill` command)
4. Stop a VM by shutting down from within the VM via VNC or the `hostmgr-helper` View option

### Stopping a VM while it's starting

1. Start a VM and test stopping it at various points (immediately, after a few seconds, right before launch, right after launch)
2. Expect that `hostmgr vm list --location local` doesn't show the bundle ID, there's no VM process in Activity Monitor, the slot it occupied is available

**Note:** It's expected that if a VM is cancelled after getting an IP, but before [`waitForSSHServer`](https://github.com/Automattic/hostmgr/blob/47ddd938967661b57d19bce75564e634c5b59e85/Sources/libhostmgr/Platforms/VMManager.swift#L219) that the `hostmgr vm start` command will time out with a `sshConnectionTimeout`.