### PR TITLE
Add timeout functionality when trying to stop a VM

### DIFF
--- a/Sources/hostmgr-helper/ManagedVirtualMachine.swift
+++ b/Sources/hostmgr-helper/ManagedVirtualMachine.swift
@@ -52,15 +52,34 @@ class ManagedVirtualMachine {
             machine.delegate = nil
             if machine.canStop {
                 do {
-                    Logger.helper.debug("Attempting to stop VM \(handle).")
-                    /// Note: It's suspected that this call may hang under certain conditions.
-                    try await machine.stop()
+                    Logger.helper.debug("Attempting to stop VM \(handle)")
+                    try await stopVMWithTimeout(machine, timeout: .seconds(15))
                 } catch {
                     Logger.helper.error("Failed to stop VM \(handle): \(error)")
                 }
             }
         }
         await cleanUp()
+    }
+
+    /// Adds a timeout to stopping VMs because it's suspected that VZVirtualMachines can get into a state
+    /// where the call to `stop()` hangs.
+    private func stopVMWithTimeout(_ vm: VZVirtualMachine, timeout: Duration) async throws {
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask { @MainActor in
+                try await vm.stop()
+                Logger.helper.debug("Successfully stopped VM")
+            }
+            group.addTask {
+                try await Task.sleep(for: timeout)
+                Logger.helper.error("Timeout reached when trying to stop VM")
+            }
+
+            /// Wait for the first task to complete
+            try await group.next()
+            /// Cancel the other task
+            group.cancelAll()
+        }
     }
 
     private func cleanUp() async {


### PR DESCRIPTION
This is a safeguard against a hanging `stop()` call (which should be relatively fast and abrupt) on a `VZVirtualMachine`. This _may not be necessary_, but we're seeing cases where CI calls `hostmgr vm stop [handle]` and the caller times out after two minutes.

The evidence we see that the call didn't complete is that:
1. We receive a timeout by our caller after two minutes
2. The VM bundle is still on the filesystem, so the [cleanup routine](https://github.com/Automattic/hostmgr/blob/82fbaeb6b5d47c89a24fc7e3e80736e05876c6eb/Sources/hostmgr-helper/VirtualMachineSlot.swift#L109) wasn't reached

After doing some investigating my conclusion is that either the `stop()` call is hanging or we've achieved some sort of deadlock. Either way this is probably our fault and not an Apple bug, (e.g. deadlock, calling the VM reference across threads, or race conditions).

I think it's unlikely this scenario is causing a crash because `hostmgr-helper` seemed to maintain its PID well after the hang. It would've been automatically restarted with a new PID by `launchd`.

This issue has happened in 0.51.0 up to 0.53.1.