### PR TITLE
Properly cancel VM start sequence to reduce race conditions

### DIFF
--- a/Sources/hostmgr-helper/VM List/States/RunningVMListItem.swift
+++ b/Sources/hostmgr-helper/VM List/States/RunningVMListItem.swift
@@ -29,7 +29,7 @@ struct RunningVMListItem: View {
 
     func shutdown() {
         Task {
-            try await slot.stopVirtualMachine()
+            try await slot.stop()
         }
     }
 

--- a/Sources/hostmgr-helper/VM List/VMListItem.swift
+++ b/Sources/hostmgr-helper/VM List/VMListItem.swift
@@ -8,7 +8,7 @@ struct VMListItem: View {
     var body: some View {
         switch slot.status {
         case .empty: EmptyVMListItem(slot: slot)
-        case .starting(let launchConfiguration):
+        case .starting(let launchConfiguration, _):
             PendingVMListItem(
                 launchConfiguration: launchConfiguration,
                 slot: slot

--- a/Sources/hostmgr-helper/VM List/VMListItem.swift
+++ b/Sources/hostmgr-helper/VM List/VMListItem.swift
@@ -13,10 +13,10 @@ struct VMListItem: View {
                 launchConfiguration: launchConfiguration,
                 slot: slot
             )
-        case .running(let mvm, let ipAddress):
+        case .running(let mvm):
             RunningVMListItem(
                 launchConfiguration: mvm.config,
-                ipAddress: ipAddress,
+                ipAddress: mvm.ip,
                 slot: slot
             )
         case .stopping:

--- a/Sources/hostmgr-helper/VM List/VMListItem.swift
+++ b/Sources/hostmgr-helper/VM List/VMListItem.swift
@@ -13,10 +13,10 @@ struct VMListItem: View {
                 launchConfiguration: launchConfiguration,
                 slot: slot
             )
-        case .running(let mvm):
+        case .running(let virtualMachine):
             RunningVMListItem(
-                launchConfiguration: mvm.config,
-                ipAddress: mvm.ip,
+                launchConfiguration: virtualMachine.config,
+                ipAddress: virtualMachine.ip,
                 slot: slot
             )
         case .stopping:

--- a/Sources/hostmgr-helper/VM List/VMListItem.swift
+++ b/Sources/hostmgr-helper/VM List/VMListItem.swift
@@ -6,7 +6,7 @@ struct VMListItem: View {
     var slot: VirtualMachineSlot
 
     var body: some View {
-        switch slot.status {
+        switch slot.state {
         case .empty: EmptyVMListItem(slot: slot)
         case .starting(let launchConfiguration, _):
             PendingVMListItem(

--- a/Sources/hostmgr-helper/VM List/VMListItem.swift
+++ b/Sources/hostmgr-helper/VM List/VMListItem.swift
@@ -13,9 +13,9 @@ struct VMListItem: View {
                 launchConfiguration: launchConfiguration,
                 slot: slot
             )
-        case .running(let launchConfiguration, let ipAddress):
+        case .running(let mvm, let ipAddress):
             RunningVMListItem(
-                launchConfiguration: launchConfiguration,
+                launchConfiguration: mvm.config,
                 ipAddress: ipAddress,
                 slot: slot
             )

--- a/Sources/hostmgr-helper/VMHost.swift
+++ b/Sources/hostmgr-helper/VMHost.swift
@@ -45,11 +45,11 @@ extension VMHost: HostmgrServerDelegate {
         Logger.helper.log("Received stop request for \(handle)")
 
         if self.primaryVMSlot.isConfiguredForHandle(handle) {
-            try await primaryVMSlot.stopVirtualMachine()
+            try await primaryVMSlot.stop()
         }
 
         if self.secondaryVMSlot.isConfiguredForHandle(handle) {
-            try await secondaryVMSlot.stopVirtualMachine()
+            try await secondaryVMSlot.stop()
         }
     }
 
@@ -58,8 +58,8 @@ extension VMHost: HostmgrServerDelegate {
 
         repeat {
             do {
-                try await self.primaryVMSlot.stopVirtualMachine()
-                try await self.secondaryVMSlot.stopVirtualMachine()
+                try await self.primaryVMSlot.stop()
+                try await self.secondaryVMSlot.stop()
                 return
             } catch {
                 try await Task.sleep(for: .seconds(1))

--- a/Sources/hostmgr-helper/VMWindow.swift
+++ b/Sources/hostmgr-helper/VMWindow.swift
@@ -10,7 +10,7 @@ struct VMWindowContent: View {
     }
 
     var body: some View {
-        switch vmSlot.status {
+        switch vmSlot.state {
         case .empty:  Text("VM not running")
         case .starting: ProgressView()
         case .running(let mvm): VirtualMachineDisplayView(virtualMachine: mvm.machine)

--- a/Sources/hostmgr-helper/VMWindow.swift
+++ b/Sources/hostmgr-helper/VMWindow.swift
@@ -13,7 +13,7 @@ struct VMWindowContent: View {
         switch vmSlot.status {
         case .empty:  Text("VM not running")
         case .starting: ProgressView()
-        case .running: VirtualMachineDisplayView(virtualMachine: vmSlot.managedVirtualMachine?.machine)
+        case .running(let mvm, _): VirtualMachineDisplayView(virtualMachine: mvm.machine)
         .onAppear {
             NSApp.setActivationPolicy(.regular)
             NSApp.activate(ignoringOtherApps: true)

--- a/Sources/hostmgr-helper/VMWindow.swift
+++ b/Sources/hostmgr-helper/VMWindow.swift
@@ -13,7 +13,7 @@ struct VMWindowContent: View {
         switch vmSlot.state {
         case .empty:  Text("VM not running")
         case .starting: ProgressView()
-        case .running(let mvm): VirtualMachineDisplayView(virtualMachine: mvm.machine)
+        case .running(let virtualMachine): VirtualMachineDisplayView(virtualMachine: virtualMachine.machine)
         .onAppear {
             NSApp.setActivationPolicy(.regular)
             NSApp.activate(ignoringOtherApps: true)

--- a/Sources/hostmgr-helper/VMWindow.swift
+++ b/Sources/hostmgr-helper/VMWindow.swift
@@ -13,7 +13,7 @@ struct VMWindowContent: View {
         switch vmSlot.status {
         case .empty:  Text("VM not running")
         case .starting: ProgressView()
-        case .running(let mvm, _): VirtualMachineDisplayView(virtualMachine: mvm.machine)
+        case .running(let mvm): VirtualMachineDisplayView(virtualMachine: mvm.machine)
         .onAppear {
             NSApp.setActivationPolicy(.regular)
             NSApp.activate(ignoringOtherApps: true)

--- a/Sources/hostmgr-helper/VirtualMachineSlot.swift
+++ b/Sources/hostmgr-helper/VirtualMachineSlot.swift
@@ -39,6 +39,8 @@ class VirtualMachineSlot: NSObject, ObservableObject {
     enum Errors: Error {
         /// The slot was asked to start a new VM when it wasn't available.
         case invalidStartState
+        /// The slot was asked to stop a VM when it was already stopping
+        case invalidStopState
         /// The VM was stopped while starting.
         case vmStartCancelled
     }
@@ -87,18 +89,21 @@ class VirtualMachineSlot: NSObject, ObservableObject {
         } catch Errors.vmStartCancelled {
             // We're already transitioning from Starting -> Stopping by an external call.
             Logger.helper.debug("Start task was cancelled for \(launchConfiguration.handle).")
-            try? await vmManager.removeVM(name: launchConfiguration.handle)
 
             throw Errors.vmStartCancelled
         } catch {
             // MARK: Starting -> Stopping
             Logger.helper.error("Error launching VM: \(error.localizedDescription)")
-            try? await stop(withError: error)
-
+            try? await stopAndClean(withError: error)
             throw error
         }
     }
 
+    /// Stops a VM running in the slot. Does not clean a stopped VM.
+    ///
+    /// This method throws an error if trying to stop in a state other than `.starting` and `.running`.
+    /// - Parameters:
+    ///   - error: Error to include if the slot is stopping because of an error.
     func stop(withError error: Error? = nil) async throws {
         Logger.helper.log("Stopping \(role.displayName) slot with current status \(state).")
         switch state {
@@ -106,16 +111,13 @@ class VirtualMachineSlot: NSObject, ObservableObject {
             // MARK: Starting -> Stopping
             self.state = .stopping(config)
             task.cancel()
-            await cleanManagedVm(config.handle)
         case .running(let mvm):
             // MARK: Running -> Stopping
             self.state = .stopping(mvm.config)
             await stopVm(mvm.machine, handle: mvm.handle)
-            await cleanManagedVm(mvm.handle)
         default:
-            /// For all other states we do nothing.
-            Logger.helper.debug("Stop called while state was \(state) - doing nothing.")
-            return
+            Logger.helper.error("Stop called while state was \(state).")
+            throw Errors.invalidStopState
         }
 
         if let error {
@@ -147,6 +149,7 @@ class VirtualMachineSlot: NSObject, ObservableObject {
         Logger.helper.debug(
             "Slot availability check: \(role.displayName) slot has \(state) status."
         )
+
         switch self.state {
         case .empty, .crashed: return true
         default: return false
@@ -169,9 +172,10 @@ class VirtualMachineSlot: NSObject, ObservableObject {
             }
             return ManagedVirtualMachine(machine: virtualMachine, config: launchConfiguration, ip: ipAddress)
         } catch {
-            // Guarantee that the VM is stopped before throwing.
+            // Guarantee that the VM is stopped and cleaned before throwing.
             Logger.helper.error("Stopping VM \(launchConfiguration.handle) that was being launched: \(error)")
             await stopVm(virtualMachine, handle: launchConfiguration.handle)
+            try? vmManager.removeVM(name: launchConfiguration.handle)
             throw error
         }
     }
@@ -192,10 +196,25 @@ class VirtualMachineSlot: NSObject, ObservableObject {
         }
     }
 
-    private func cleanManagedVm(_ handle: String) async {
+    /// Used internally by the class when it needs to stop the VM and run the clean up step afterwards. This may
+    /// be called because of an "external" event: A VM gracefully stopped via macOS, crashed, or failed to initialize.
+    ///
+    /// VMs typically stop via the `hostmgr stop` command which handles cleanup on its own.
+    /// Only ephemeral VM files are removed.
+    /// - Parameters:
+    ///   - error: Error to include if the slot is stopping because of an error.
+    ///   - cleanAllTypes: If `true` the VM will be deleted even if a persistent or template type.
+    private func stopAndClean(withError error: Error? = nil) async throws {
+        Logger.helper.log("Stopping and cleaning \(role.displayName).")
+        try await stop(withError: error)
+        guard let handle = state.handle else {
+            return
+        }
+
         Logger.helper.log("Cleaning up VM \(handle).")
         do {
-            try await vmManager.removeVM(name: handle)
+            // Remove working (ephemeral) VMs only
+            try vmManager.removeWorkingVM(handle: handle)
             Logger.helper.log("Cleaned up VM \(handle).")
         } catch {
             Logger.helper.error("Failure when removing VM files: \(error)")
@@ -209,14 +228,15 @@ extension VirtualMachineSlot: VZVirtualMachineDelegate {
     nonisolated func guestDidStop(_ virtualMachine: VZVirtualMachine) {
         Logger.helper.log("Virtual Machine Stopped")
         Task {
-            try await stop()
+            try await stopAndClean()
+
         }
     }
 
     nonisolated func virtualMachine(_ virtualMachine: VZVirtualMachine, didStopWithError error: Error) {
         Logger.helper.error("Virtual Machine Crashed: \(error.localizedDescription)")
         Task {
-            try await stop(withError: error)
+            try await stopAndClean(withError: error)
         }
     }
 
@@ -227,7 +247,7 @@ extension VirtualMachineSlot: VZVirtualMachineDelegate {
     ) {
         Logger.helper.error("Network attachment was disconnected: \(error.localizedDescription)")
         Task {
-            try await stop()
+            try await stopAndClean()
         }
     }
 }

--- a/Sources/hostmgr-helper/VirtualMachineSlot.swift
+++ b/Sources/hostmgr-helper/VirtualMachineSlot.swift
@@ -108,7 +108,7 @@ class VirtualMachineSlot: NSObject, ObservableObject {
 
     private func stopManagedVm(_ mvm: ManagedVirtualMachine) async {
         Logger.helper.log("Stopping VM \(mvm.handle).")
-        /// Quit responding to delegate methods
+        // Quit responding to delegate methods
         mvm.machine.delegate = nil
         do {
             if mvm.machine.canStop {

--- a/Sources/hostmgr-helper/VirtualMachineSlot.swift
+++ b/Sources/hostmgr-helper/VirtualMachineSlot.swift
@@ -20,131 +20,150 @@ class VirtualMachineSlot: NSObject, ObservableObject {
     enum Status: Sendable {
         case empty
         case starting(LaunchConfiguration, Task<ManagedVirtualMachine, Error>)
-        case running(LaunchConfiguration, IPv4Address)
-        case stopping
+        case running(ManagedVirtualMachine, IPv4Address)
+        case stopping(LaunchConfiguration)
         case crashed(Error)
+    }
+
+    enum Errors: Error {
+        /// the slot was asked to start a new VM when it wasn't available
+        case invalidStartState
+        /// the VM was stopped while starting
+        case vmStartCancelled
     }
 
     struct ManagedVirtualMachine {
         let machine: VZVirtualMachine
         let config: LaunchConfiguration
         let ip: IPv4Address
+
+        var handle: String {
+            config.handle
+        }
     }
 
     private let vmManager = VMManager()
 
     @Published
-    var managedVirtualMachine: ManagedVirtualMachine?
-
-    @Published @MainActor
     var status: Status = .empty
 
-    @Published @MainActor
-    var role: Role
+    let role: Role
 
     init(role: Role) {
         self.role = role
     }
 
-    @MainActor
     func start(launchConfiguration: LaunchConfiguration) async throws {
-        let startTask = createStartTask(launchConfiguration: launchConfiguration)
-        self.status = .starting(launchConfiguration, startTask)
+        guard isAvailable else {
+            throw Errors.invalidStartState
+        }
 
         do {
+            let startTask = Task {
+                try await createManagedVm(launchConfiguration: launchConfiguration)
+            }
+
+            self.status = .starting(launchConfiguration, startTask)
             let newVM = try await startTask.value
+            if startTask.isCancelled {
+                Logger.helper.debug("Start task was cancelled for \(newVM.handle)")
+                throw Errors.vmStartCancelled
+            }
+
             newVM.machine.delegate = self
-            self.managedVirtualMachine = newVM
-            self.status = .running(launchConfiguration, newVM.ip)
+            Logger.helper.log("Setting \(role.displayName) slot to running \(newVM.handle).")
+            self.status = .running(newVM, newVM.ip)
         } catch {
             Logger.helper.error("Error launching VM: \(error.localizedDescription)")
-            Logger.helper.error("Attempting Cleanup of \(launchConfiguration.handle)")
-
-            do {
-                try await vmManager.removeVM(name: launchConfiguration.handle)
-            } catch {
-                Logger.helper.error("Failed to remove VM file: \(error)")
-            }
-            self.managedVirtualMachine = nil
-            self.status = .crashed(error)
+            try? await stop(withError: error)
             throw error
         }
     }
 
-    @MainActor
-    private func createStartTask(launchConfiguration: LaunchConfiguration) -> Task<ManagedVirtualMachine, Error> {
-        Task {
-            let virtualMachine = try await launchConfiguration.setupVirtualMachine()
-            try await virtualMachine.start()
+    private func createManagedVm(launchConfiguration: LaunchConfiguration) async throws -> ManagedVirtualMachine {
+        Logger.helper.log("Creating VM \(launchConfiguration.handle).")
+        let virtualMachine = try await launchConfiguration.setupVirtualMachine()
+        try await virtualMachine.start()
 
-            let ipAddress: IPv4Address
-            if launchConfiguration.waitForNetworking {
-                ipAddress = try await vmManager.ipAddress(forVmWithName: launchConfiguration.handle)
-                Logger.helper.log("Startup complete – IP Address: \(ipAddress.debugDescription)")
-            } else {
-                Logger.helper.log("Startup in progress – skipped waiting for IP address per launch configuration")
-                ipAddress = .any
+        let ipAddress: IPv4Address
+        if launchConfiguration.waitForNetworking {
+            ipAddress = try await vmManager.ipAddress(forVmWithName: launchConfiguration.handle)
+            Logger.helper.log("Startup complete – IP Address: \(ipAddress.debugDescription)")
+        } else {
+            Logger.helper.log("Startup in progress – skipped waiting for IP address per launch configuration")
+            ipAddress = .any
+        }
+        return ManagedVirtualMachine(machine: virtualMachine, config: launchConfiguration, ip: ipAddress)
+    }
+
+    private func stopManagedVm(_ mvm: ManagedVirtualMachine) async {
+        Logger.helper.log("Stopping VM \(mvm.handle).")
+        /// Quit responding to delegate methods
+        mvm.machine.delegate = nil
+        do {
+            if mvm.machine.canStop {
+                try await mvm.machine.stop()
             }
-            return ManagedVirtualMachine(machine: virtualMachine, config: launchConfiguration, ip: ipAddress)
+        } catch {
+            Logger.helper.error("Failure when stopping VM: \(error)")
         }
     }
 
-    @MainActor
-    func stop() async throws {
+    private func cleanManagedVM(_ handle: String) async {
+        Logger.helper.log("Cleaning up VM \(handle).")
+        do {
+            try await vmManager.removeVM(name: handle)
+        } catch {
+            Logger.helper.error("Failure when removing VM files: \(error)")
+        }
+    }
+
+    func stop(withError error: Error? = nil) async throws {
+        Logger.helper.log("Stopping \(role.displayName) slot.")
         switch status {
-        case .starting(_, let task):
+        case .starting(let config, let task):
+            self.status = .stopping(config)
             task.cancel()
-            self.status = .stopping
-        case .running:
-            self.status = .stopping
+            await cleanManagedVM(config.handle)
+        case .running(let mvm, _):
+            self.status = .stopping(mvm.config)
+            await stopManagedVm(mvm)
+            await cleanManagedVM(mvm.handle)
         default:
-            break
-        }
-        if let machine = managedVirtualMachine?.machine, machine.canStop {
-            do {
-                try await machine.stop()
-            } catch {
-                Logger.helper.error("Failed to stop VM: \(error)")
-            }
-        }
-        await resetSlot()
-    }
-
-    /// Resets the slot to a stopped status
-    ///
-    /// No need to do anything except some internal bookkeeping
-    /// - Parameter error: Error supplied if the VM crashed
-    @MainActor
-    func resetSlot(withError error: Error? = nil) async {
-        if let managedVirtualMachine {
-            do {
-                try await vmManager.removeVM(name: managedVirtualMachine.config.handle)
-            } catch {
-                Logger.helper.error("Failed to remove VM file: \(error)")
-            }
-            self.managedVirtualMachine = nil
+            /// For all other states we do nothing.
+            Logger.helper.debug("Stop called while state was \(status) - doing nothing.")
+            return
         }
 
         if let error {
             Logger.helper.error("Resetting slot with crashed state: \(error)")
             self.status = .crashed(error)
         } else {
+            Logger.helper.log("Resetting slot to empty state.")
             self.status = .empty
         }
     }
 
-    @MainActor
     func isConfiguredForHandle(_ handle: String) -> Bool {
-        guard let configHandle = managedVirtualMachine?.config.handle else {
+        switch status {
+        case .starting(let config, _), .stopping(let config):
+            Logger.helper.debug(
+                "Comparing \(config.handle) and \(handle)"
+            )
+            return config.handle == handle
+        case .running(let mvm, _):
+            Logger.helper.debug(
+                "Comparing \(mvm.config.handle) and \(handle)"
+            )
+            return mvm.config.handle == handle
+        case .empty, .crashed:
+            Logger.helper.debug(
+                "\(self.role) slot had no handle configured."
+            )
             return false
         }
-        Logger.helper.debug(
-            "Comparing \(configHandle) and \(handle)"
-        )
-        return configHandle == handle
     }
 
-    @MainActor
     var isAvailable: Bool {
         switch self.status {
         case .empty, .crashed: return true
@@ -159,14 +178,14 @@ extension VirtualMachineSlot: VZVirtualMachineDelegate {
     nonisolated func guestDidStop(_ virtualMachine: VZVirtualMachine) {
         Logger.helper.log("Virtual Machine Stopped")
         Task {
-            await resetSlot()
+            try await stop()
         }
     }
 
     nonisolated func virtualMachine(_ virtualMachine: VZVirtualMachine, didStopWithError error: Error) {
         Logger.helper.error("Virtual Machine Crashed: \(error.localizedDescription)")
         Task {
-            await resetSlot(withError: error)
+            try await stop(withError: error)
         }
     }
 

--- a/Sources/hostmgr-helper/VirtualMachineSlot.swift
+++ b/Sources/hostmgr-helper/VirtualMachineSlot.swift
@@ -90,7 +90,7 @@ class VirtualMachineSlot: NSObject, ObservableObject {
     }
 
     @MainActor
-    func stopVirtualMachine() async throws {
+    func stop() async throws {
         switch status {
         case .starting(_, let task):
             task.cancel()
@@ -177,7 +177,7 @@ extension VirtualMachineSlot: VZVirtualMachineDelegate {
     ) {
         Logger.helper.error("Network attachment was disconnected: \(error.localizedDescription)")
         Task {
-            try await stopVirtualMachine()
+            try await stop()
         }
     }
 }

--- a/Sources/hostmgr-helper/VirtualMachineSlot.swift
+++ b/Sources/hostmgr-helper/VirtualMachineSlot.swift
@@ -229,7 +229,6 @@ extension VirtualMachineSlot: VZVirtualMachineDelegate {
         Logger.helper.log("Virtual Machine Stopped")
         Task {
             try await stopAndClean()
-
         }
     }
 

--- a/Sources/hostmgr-helper/VirtualMachineSlot.swift
+++ b/Sources/hostmgr-helper/VirtualMachineSlot.swift
@@ -112,6 +112,7 @@ class VirtualMachineSlot: NSObject, ObservableObject {
         mvm.machine.delegate = nil
         do {
             if mvm.machine.canStop {
+                Logger.helper.debug("VM \(mvm.handle) claims it can be stopped.")
                 try await mvm.machine.stop()
                 Logger.helper.log("Stopped VM \(mvm.handle).")
             }

--- a/Sources/hostmgr-helper/VirtualMachineSlot.swift
+++ b/Sources/hostmgr-helper/VirtualMachineSlot.swift
@@ -72,62 +72,30 @@ class VirtualMachineSlot: NSObject, ObservableObject {
         }
 
         do {
+            // MARK: Empty / Crashed -> Starting
             let startTask = Task { try await createManagedVm(launchConfiguration: launchConfiguration) }
             self.state = .starting(launchConfiguration, startTask)
             let newVM = try await startTask.value
-            if startTask.isCancelled {
-                Logger.helper.debug("Start task was cancelled for \(newVM.handle).")
-                throw Errors.vmStartCancelled
-            }
+            // stop() was called while the VM was starting.
+            if startTask.isCancelled { throw Errors.vmStartCancelled }
 
+            // MARK: Starting -> Running
             Logger.helper.log("Setting \(role.displayName) slot to running \(newVM.handle).")
             newVM.machine.delegate = self
+
             self.state = .running(newVM)
+        } catch Errors.vmStartCancelled {
+            // We're already transitioning from Starting -> Stopping by an external call.
+            Logger.helper.debug("Start task was cancelled for \(launchConfiguration.handle).")
+            try? await vmManager.removeVM(name: launchConfiguration.handle)
+
+            throw Errors.vmStartCancelled
         } catch {
+            // MARK: Starting -> Stopping
             Logger.helper.error("Error launching VM: \(error.localizedDescription)")
             try? await stop(withError: error)
+
             throw error
-        }
-    }
-
-    private func createManagedVm(launchConfiguration: LaunchConfiguration) async throws -> ManagedVirtualMachine {
-        Logger.helper.log("Creating VM \(launchConfiguration.handle).")
-        let virtualMachine = try await launchConfiguration.setupVirtualMachine()
-        try await virtualMachine.start()
-
-        let ipAddress: IPv4Address
-        if launchConfiguration.waitForNetworking {
-            ipAddress = try await vmManager.ipAddress(forVmWithName: launchConfiguration.handle)
-            Logger.helper.log("Startup complete – IP Address: \(ipAddress.debugDescription).")
-        } else {
-            Logger.helper.log("Startup in progress – skipped waiting for IP address per launch configuration.")
-            ipAddress = .any
-        }
-        return ManagedVirtualMachine(machine: virtualMachine, config: launchConfiguration, ip: ipAddress)
-    }
-
-    private func stopManagedVm(_ mvm: ManagedVirtualMachine) async {
-        Logger.helper.log("Stopping VM \(mvm.handle).")
-        // Quit responding to delegate methods
-        mvm.machine.delegate = nil
-        do {
-            if mvm.machine.canStop {
-                Logger.helper.debug("VM \(mvm.handle) claims it can be stopped.")
-                try await mvm.machine.stop()
-                Logger.helper.log("Stopped VM \(mvm.handle).")
-            }
-        } catch {
-            Logger.helper.error("Failure when stopping VM: \(error)")
-        }
-    }
-
-    private func cleanManagedVm(_ handle: String) async {
-        Logger.helper.log("Cleaning up VM \(handle).")
-        do {
-            try await vmManager.removeVM(name: handle)
-            Logger.helper.log("Cleaned up VM \(handle).")
-        } catch {
-            Logger.helper.error("Failure when removing VM files: \(error)")
         }
     }
 
@@ -135,12 +103,14 @@ class VirtualMachineSlot: NSObject, ObservableObject {
         Logger.helper.log("Stopping \(role.displayName) slot with current status \(state).")
         switch state {
         case .starting(let config, let task):
+            // MARK: Starting -> Stopping
             self.state = .stopping(config)
             task.cancel()
             await cleanManagedVm(config.handle)
         case .running(let mvm):
+            // MARK: Running -> Stopping
             self.state = .stopping(mvm.config)
-            await stopManagedVm(mvm)
+            await stopVm(mvm.machine, handle: mvm.handle)
             await cleanManagedVm(mvm.handle)
         default:
             /// For all other states we do nothing.
@@ -149,9 +119,11 @@ class VirtualMachineSlot: NSObject, ObservableObject {
         }
 
         if let error {
+            // MARK: Stopping -> Crashed
             Logger.helper.error("Resetting slot with crashed state: \(error)")
             self.state = .crashed(error)
         } else {
+            // MARK: Stopping -> Empty
             Logger.helper.log("Resetting slot to empty state.")
             self.state = .empty
         }
@@ -178,6 +150,55 @@ class VirtualMachineSlot: NSObject, ObservableObject {
         switch self.state {
         case .empty, .crashed: return true
         default: return false
+        }
+    }
+
+    private func createManagedVm(launchConfiguration: LaunchConfiguration) async throws -> ManagedVirtualMachine {
+        Logger.helper.log("Creating VM \(launchConfiguration.handle).")
+        let virtualMachine = try await launchConfiguration.setupVirtualMachine()
+        try await virtualMachine.start()
+
+        do {
+            let ipAddress: IPv4Address
+            if launchConfiguration.waitForNetworking {
+                ipAddress = try await vmManager.ipAddress(forVmWithName: launchConfiguration.handle)
+                Logger.helper.log("Startup complete – IP Address: \(ipAddress.debugDescription).")
+            } else {
+                Logger.helper.log("Startup in progress – skipped waiting for IP address per launch configuration.")
+                ipAddress = .any
+            }
+            return ManagedVirtualMachine(machine: virtualMachine, config: launchConfiguration, ip: ipAddress)
+        } catch {
+            // Guarantee that the VM is stopped before throwing.
+            Logger.helper.error("Stopping VM \(launchConfiguration.handle) that was being launched: \(error)")
+            await stopVm(virtualMachine, handle: launchConfiguration.handle)
+            throw error
+        }
+    }
+
+    private func stopVm(_ vm: VZVirtualMachine, handle: String) async {
+        Logger.helper.log("Stopping VM \(handle).")
+        // Quit responding to delegate methods.
+        vm.delegate = nil
+
+        if vm.canStop {
+            Logger.helper.debug("VM \(handle) claims it can be stopped.")
+            do {
+                try await vm.stop()
+                Logger.helper.log("Stopped VM \(handle).")
+            } catch {
+                Logger.helper.error("Failure when stopping VM: \(error)")
+            }
+        }
+    }
+
+    private func cleanManagedVm(_ handle: String) async {
+        Logger.helper.log("Cleaning up VM \(handle).")
+        do {
+            try await vmManager.removeVM(name: handle)
+            Logger.helper.log("Cleaned up VM \(handle).")
+        } catch {
+            Logger.helper.error("Failure when removing VM files: \(error)")
         }
     }
 }

--- a/Sources/hostmgr-helper/VirtualMachineSlot.swift
+++ b/Sources/hostmgr-helper/VirtualMachineSlot.swift
@@ -68,7 +68,8 @@ class VirtualMachineSlot: NSObject, ObservableObject {
 
     /// Requests that the slot go to a running state with a VM configured by `launchConfiguration`.
     ///
-    /// This method throws an error if trying to start in an invalid state, or if there was an error initializing the VM.
+    /// This method throws an error if trying to start in an invalid state, or if there was an error
+    /// initializing the VM.
     /// - Parameter launchConfiguration: VM configuration.
     func start(launchConfiguration: LaunchConfiguration) async throws {
         Logger.helper.log("Launch request for \(launchConfiguration.handle).")

--- a/Sources/hostmgr-helper/VirtualMachineSlot.swift
+++ b/Sources/hostmgr-helper/VirtualMachineSlot.swift
@@ -184,6 +184,8 @@ class VirtualMachineSlot: NSObject, ObservableObject {
         if vm.canStop {
             Logger.helper.debug("VM \(handle) claims it can be stopped.")
             do {
+                // An attempt to help with https://github.com/Automattic/hostmgr/issues/128
+                vm.networkDevices.forEach { $0.attachment = nil }
                 try await vm.stop()
                 Logger.helper.log("Stopped VM \(handle).")
             } catch {

--- a/Sources/hostmgr-helper/VirtualMachineSlot.swift
+++ b/Sources/hostmgr-helper/VirtualMachineSlot.swift
@@ -54,24 +54,23 @@ class VirtualMachineSlot: NSObject, ObservableObject {
     }
 
     func start(launchConfiguration: LaunchConfiguration) async throws {
+        Logger.helper.log("Launch request for \(launchConfiguration.handle).")
+
         guard isAvailable else {
             throw Errors.invalidStartState
         }
 
         do {
-            let startTask = Task {
-                try await createManagedVm(launchConfiguration: launchConfiguration)
-            }
-
+            let startTask = Task { try await createManagedVm(launchConfiguration: launchConfiguration) }
             self.status = .starting(launchConfiguration, startTask)
             let newVM = try await startTask.value
             if startTask.isCancelled {
-                Logger.helper.debug("Start task was cancelled for \(newVM.handle)")
+                Logger.helper.debug("Start task was cancelled for \(newVM.handle).")
                 throw Errors.vmStartCancelled
             }
 
-            newVM.machine.delegate = self
             Logger.helper.log("Setting \(role.displayName) slot to running \(newVM.handle).")
+            newVM.machine.delegate = self
             self.status = .running(newVM)
         } catch {
             Logger.helper.error("Error launching VM: \(error.localizedDescription)")
@@ -88,9 +87,9 @@ class VirtualMachineSlot: NSObject, ObservableObject {
         let ipAddress: IPv4Address
         if launchConfiguration.waitForNetworking {
             ipAddress = try await vmManager.ipAddress(forVmWithName: launchConfiguration.handle)
-            Logger.helper.log("Startup complete – IP Address: \(ipAddress.debugDescription)")
+            Logger.helper.log("Startup complete – IP Address: \(ipAddress.debugDescription).")
         } else {
-            Logger.helper.log("Startup in progress – skipped waiting for IP address per launch configuration")
+            Logger.helper.log("Startup in progress – skipped waiting for IP address per launch configuration.")
             ipAddress = .any
         }
         return ManagedVirtualMachine(machine: virtualMachine, config: launchConfiguration, ip: ipAddress)
@@ -103,6 +102,7 @@ class VirtualMachineSlot: NSObject, ObservableObject {
         do {
             if mvm.machine.canStop {
                 try await mvm.machine.stop()
+                Logger.helper.log("Stopped VM \(mvm.handle).")
             }
         } catch {
             Logger.helper.error("Failure when stopping VM: \(error)")
@@ -113,13 +113,14 @@ class VirtualMachineSlot: NSObject, ObservableObject {
         Logger.helper.log("Cleaning up VM \(handle).")
         do {
             try await vmManager.removeVM(name: handle)
+            Logger.helper.log("Cleaned up VM \(handle).")
         } catch {
             Logger.helper.error("Failure when removing VM files: \(error)")
         }
     }
 
     func stop(withError error: Error? = nil) async throws {
-        Logger.helper.log("Stopping \(role.displayName) slot.")
+        Logger.helper.log("Stopping \(role.displayName) slot with current status \(status).")
         switch status {
         case .starting(let config, let task):
             self.status = .stopping(config)
@@ -145,26 +146,33 @@ class VirtualMachineSlot: NSObject, ObservableObject {
     }
 
     func isConfiguredForHandle(_ handle: String) -> Bool {
+        let slotHandle: String?
         switch status {
         case .starting(let config, _), .stopping(let config):
-            Logger.helper.debug(
-                "Comparing \(config.handle) and \(handle)"
-            )
-            return config.handle == handle
+            slotHandle = config.handle
         case .running(let mvm):
-            Logger.helper.debug(
-                "Comparing \(mvm.handle) and \(handle)"
-            )
-            return mvm.handle == handle
+            slotHandle = mvm.handle
         case .empty, .crashed:
+            slotHandle = nil
+        }
+
+        guard let slotHandle else {
             Logger.helper.debug(
-                "\(self.role) slot had no handle configured."
+                "\(role.displayName) slot had no handle configured."
             )
             return false
         }
+
+        Logger.helper.debug(
+            "Comparing \(slotHandle) and \(handle)."
+        )
+        return slotHandle == handle
     }
 
     var isAvailable: Bool {
+        Logger.helper.debug(
+            "Slot availability check: \(role.displayName) slot has \(status) status."
+        )
         switch self.status {
         case .empty, .crashed: return true
         default: return false

--- a/Sources/hostmgr-helper/VirtualMachineSlot.swift
+++ b/Sources/hostmgr-helper/VirtualMachineSlot.swift
@@ -175,6 +175,7 @@ class VirtualMachineSlot: NSObject, ObservableObject {
             // Guarantee that the VM is stopped and cleaned before throwing.
             Logger.helper.error("Stopping VM \(launchConfiguration.handle) that was being launched: \(error)")
             await stopVm(virtualMachine, handle: launchConfiguration.handle)
+            // Note: This cleans ALL types of VMs that failed to start - even persistent
             try? vmManager.removeVM(name: launchConfiguration.handle)
             throw error
         }
@@ -203,7 +204,6 @@ class VirtualMachineSlot: NSObject, ObservableObject {
     /// Only ephemeral VM files are removed.
     /// - Parameters:
     ///   - error: Error to include if the slot is stopping because of an error.
-    ///   - cleanAllTypes: If `true` the VM will be deleted even if a persistent or template type.
     private func stopAndClean(withError error: Error? = nil) async throws {
         Logger.helper.log("Stopping and cleaning \(role.displayName).")
         try await stop(withError: error)

--- a/Sources/hostmgr-helper/VirtualMachineSlot.swift
+++ b/Sources/hostmgr-helper/VirtualMachineSlot.swift
@@ -131,7 +131,7 @@ class VirtualMachineSlot: NSObject, ObservableObject {
             await stopManagedVm(mvm)
             await cleanManagedVm(mvm.handle)
         default:
-            /// For all other states we do nothing.
+            // For all other states we do nothing.
             Logger.helper.debug("Stop called while state was \(status) - doing nothing.")
             return
         }

--- a/Sources/hostmgr-helper/VirtualMachineSlot.swift
+++ b/Sources/hostmgr-helper/VirtualMachineSlot.swift
@@ -170,10 +170,14 @@ class VirtualMachineSlot: NSObject, ObservableObject {
     /// - Returns: A `ManagedVirtualMachine` containing a running VM.
     private func createManagedVm(launchConfiguration: LaunchConfiguration) async throws -> ManagedVirtualMachine {
         Logger.helper.log("Creating VM \(launchConfiguration.handle).")
-        let virtualMachine = try await launchConfiguration.setupVirtualMachine()
-        try await virtualMachine.start()
+        // Maintain a reference to the new VM for clean up purposes.
+        var newVM: VZVirtualMachine?
 
         do {
+            let virtualMachine = try await launchConfiguration.setupVirtualMachine()
+            newVM = virtualMachine
+            try await virtualMachine.start()
+
             let ipAddress: IPv4Address
             if launchConfiguration.waitForNetworking {
                 ipAddress = try await vmManager.ipAddress(forVmWithName: launchConfiguration.handle)
@@ -186,7 +190,9 @@ class VirtualMachineSlot: NSObject, ObservableObject {
         } catch {
             // Guarantee that the VM is stopped and cleaned before throwing.
             Logger.helper.error("Stopping VM \(launchConfiguration.handle) that was being launched: \(error)")
-            await stopVm(virtualMachine, handle: launchConfiguration.handle)
+            if let newVM {
+                await stopVm(newVM, handle: launchConfiguration.handle)
+            }
             // Note: This cleans ALL types of VMs that failed to start - even persistent
             try? vmManager.removeVM(name: launchConfiguration.handle)
             throw error

--- a/Sources/hostmgr-helper/VirtualMachineSlot.swift
+++ b/Sources/hostmgr-helper/VirtualMachineSlot.swift
@@ -66,6 +66,10 @@ class VirtualMachineSlot: NSObject, ObservableObject {
         self.role = role
     }
 
+    /// Requests that the slot go to a running state with a VM configured by `launchConfiguration`.
+    ///
+    /// This method throws an error if trying to start in an invalid state, or if there was an error initializing the VM.
+    /// - Parameter launchConfiguration: VM configuration.
     func start(launchConfiguration: LaunchConfiguration) async throws {
         Logger.helper.log("Launch request for \(launchConfiguration.handle).")
 
@@ -94,14 +98,16 @@ class VirtualMachineSlot: NSObject, ObservableObject {
         } catch {
             // MARK: Starting -> Stopping
             Logger.helper.error("Error launching VM: \(error.localizedDescription)")
-            try? await stopAndClean(withError: error)
+            // We only call stop to reset the slot state - VM stopping and cleanup already occurred.
+            try? await stop(withError: error)
             throw error
         }
     }
 
-    /// Stops a VM running in the slot. Does not clean a stopped VM.
+    /// Puts the slot into a stopped state if it's a valid request.
     ///
-    /// This method throws an error if trying to stop in a state other than `.starting` and `.running`.
+    /// - This method does not clean up stopped VMs.
+    /// - This method throws an error if trying to stop in a state other than `.starting` and `.running`.
     /// - Parameters:
     ///   - error: Error to include if the slot is stopping because of an error.
     func stop(withError error: Error? = nil) async throws {
@@ -156,6 +162,11 @@ class VirtualMachineSlot: NSObject, ObservableObject {
         }
     }
 
+    /// Creates a running VM inside a `ManagedVirtualMachine` configured by a `LaunchConfiguration`.
+    ///
+    /// If any errors occur after the VM was started, this method will attempt to stop the VM and perform a cleanup.
+    /// - Parameter launchConfiguration: VM configuration.
+    /// - Returns: A `ManagedVirtualMachine` containing a running VM.
     private func createManagedVm(launchConfiguration: LaunchConfiguration) async throws -> ManagedVirtualMachine {
         Logger.helper.log("Creating VM \(launchConfiguration.handle).")
         let virtualMachine = try await launchConfiguration.setupVirtualMachine()
@@ -196,9 +207,12 @@ class VirtualMachineSlot: NSObject, ObservableObject {
             }
         }
     }
+}
 
+// MARK: VZVirtualMachineDelegate conformance
+extension VirtualMachineSlot: VZVirtualMachineDelegate {
     /// Used internally by the class when it needs to stop the VM and run the clean up step afterwards. This may
-    /// be called because of an "external" event: A VM gracefully stopped via macOS, crashed, or failed to initialize.
+    /// be called because of an "external" event via the `VZVirtualMachineDelegate` calls.
     ///
     /// VMs typically stop via the `hostmgr stop` command which handles cleanup on its own.
     /// Only ephemeral VM files are removed.
@@ -213,18 +227,15 @@ class VirtualMachineSlot: NSObject, ObservableObject {
 
         Logger.helper.log("Cleaning up VM \(handle).")
         do {
-            // Remove working (ephemeral) VMs only
+            // Remove working (ephemeral) VMs only.
             try vmManager.removeWorkingVM(handle: handle)
             Logger.helper.log("Cleaned up VM \(handle).")
         } catch {
             Logger.helper.error("Failure when removing VM files: \(error)")
         }
     }
-}
 
-// MARK: VZVirtualMachineDelegate conformance
-extension VirtualMachineSlot: VZVirtualMachineDelegate {
-    /// Called when a VM is stopped gracefully
+    /// Called when a VM is stopped gracefully.
     nonisolated func guestDidStop(_ virtualMachine: VZVirtualMachine) {
         Logger.helper.log("Virtual Machine Stopped")
         Task {

--- a/Sources/hostmgr-helper/VirtualMachineSlot.swift
+++ b/Sources/hostmgr-helper/VirtualMachineSlot.swift
@@ -34,6 +34,39 @@ class VirtualMachineSlot: NSObject, ObservableObject {
                 return nil
             }
         }
+
+        mutating func transitionTo(newState: State) {
+            switch (self, newState) {
+            case (.empty, .starting):
+                // Starting a new VM from a clean state.
+                break
+            case (.crashed, .starting):
+                // Starting a new VM from a previously crashed state.
+                break
+            case (.starting, .running):
+                // A VM is now running.
+                break
+            case (.starting, .stopping):
+                // A VM's start failed or was cancelled.
+                break
+            case (.running, .stopping):
+                // A VM that was successfully running is stopping.
+                break
+            case (.stopping, .empty):
+                // The VM cleanly stopped.
+                break
+            case (.stopping, .crashed):
+                // The VM stopped due to an error.
+                break
+            default:
+                // Invalid transition.
+                Logger.helper.error("An invalid state change was called from \(self) to \(newState).")
+                return
+            }
+
+            Logger.helper.info("Slot state transitioned from \(self) to \(newState).")
+            self = newState
+        }
     }
 
     enum Errors: Error {
@@ -81,7 +114,7 @@ class VirtualMachineSlot: NSObject, ObservableObject {
         do {
             // MARK: Empty / Crashed -> Starting
             let startTask = Task { try await createManagedVm(launchConfiguration: launchConfiguration) }
-            self.state = .starting(launchConfiguration, startTask)
+            self.state.transitionTo(newState: .starting(launchConfiguration, startTask))
             let newVM = try await startTask.value
             // stop() was called while the VM was starting.
             if startTask.isCancelled { throw Errors.vmStartCancelled }
@@ -90,7 +123,7 @@ class VirtualMachineSlot: NSObject, ObservableObject {
             Logger.helper.log("Setting \(role.displayName) slot to running \(newVM.handle).")
             newVM.machine.delegate = self
 
-            self.state = .running(newVM)
+            self.state.transitionTo(newState: .running(newVM))
         } catch Errors.vmStartCancelled {
             // We're already transitioning from Starting -> Stopping by an external call.
             Logger.helper.debug("Start task was cancelled for \(launchConfiguration.handle).")
@@ -116,11 +149,11 @@ class VirtualMachineSlot: NSObject, ObservableObject {
         switch state {
         case .starting(let config, let task):
             // MARK: Starting -> Stopping
-            self.state = .stopping(config)
+            self.state.transitionTo(newState: .stopping(config))
             task.cancel()
         case .running(let mvm):
             // MARK: Running -> Stopping
-            self.state = .stopping(mvm.config)
+            self.state.transitionTo(newState: .stopping(mvm.config))
             await stopVm(mvm.machine, handle: mvm.handle)
         default:
             Logger.helper.error("Stop called while state was \(state).")
@@ -130,11 +163,11 @@ class VirtualMachineSlot: NSObject, ObservableObject {
         if let error {
             // MARK: Stopping -> Crashed
             Logger.helper.error("Resetting slot with crashed state: \(error)")
-            self.state = .crashed(error)
+            self.state.transitionTo(newState: .crashed(error))
         } else {
             // MARK: Stopping -> Empty
             Logger.helper.log("Resetting slot to empty state.")
-            self.state = .empty
+            self.state.transitionTo(newState: .empty)
         }
     }
 

--- a/Sources/hostmgr-helper/VirtualMachineSlot.swift
+++ b/Sources/hostmgr-helper/VirtualMachineSlot.swift
@@ -23,6 +23,17 @@ class VirtualMachineSlot: NSObject, ObservableObject {
         case running(ManagedVirtualMachine)
         case stopping(LaunchConfiguration)
         case crashed(Error)
+
+        var handle: String? {
+            switch self {
+            case .starting(let config, _), .stopping(let config):
+                return config.handle
+            case .running(let mvm):
+                return mvm.handle
+            case .empty, .crashed:
+                return nil
+            }
+        }
     }
 
     enum Errors: Error {
@@ -146,17 +157,7 @@ class VirtualMachineSlot: NSObject, ObservableObject {
     }
 
     func isConfiguredForHandle(_ handle: String) -> Bool {
-        let slotHandle: String?
-        switch state {
-        case .starting(let config, _), .stopping(let config):
-            slotHandle = config.handle
-        case .running(let mvm):
-            slotHandle = mvm.handle
-        case .empty, .crashed:
-            slotHandle = nil
-        }
-
-        guard let slotHandle else {
+        guard let slotHandle = state.handle else {
             Logger.helper.debug(
                 "\(role.displayName) slot had no handle configured."
             )

--- a/Sources/hostmgr-helper/VirtualMachineSlot.swift
+++ b/Sources/hostmgr-helper/VirtualMachineSlot.swift
@@ -26,9 +26,9 @@ class VirtualMachineSlot: NSObject, ObservableObject {
     }
 
     enum Errors: Error {
-        /// the slot was asked to start a new VM when it wasn't available
+        /// The slot was asked to start a new VM when it wasn't available.
         case invalidStartState
-        /// the VM was stopped while starting
+        /// The VM was stopped while starting.
         case vmStartCancelled
     }
 

--- a/Sources/hostmgr-helper/VirtualMachineSlot.swift
+++ b/Sources/hostmgr-helper/VirtualMachineSlot.swift
@@ -19,7 +19,7 @@ class VirtualMachineSlot: NSObject, ObservableObject {
 
     enum Status: Sendable {
         case empty
-        case starting(LaunchConfiguration)
+        case starting(LaunchConfiguration, Task<ManagedVirtualMachine, Error>)
         case running(LaunchConfiguration, IPv4Address)
         case stopping
         case crashed(Error)
@@ -28,6 +28,7 @@ class VirtualMachineSlot: NSObject, ObservableObject {
     struct ManagedVirtualMachine {
         let machine: VZVirtualMachine
         let config: LaunchConfiguration
+        let ip: IPv4Address
     }
 
     private let vmManager = VMManager()
@@ -47,24 +48,14 @@ class VirtualMachineSlot: NSObject, ObservableObject {
 
     @MainActor
     func start(launchConfiguration: LaunchConfiguration) async throws {
-
-        self.status = .starting(launchConfiguration)
+        let startTask = createStartTask(launchConfiguration: launchConfiguration)
+        self.status = .starting(launchConfiguration, startTask)
 
         do {
-            let virtualMachine = try await launchConfiguration.setupVirtualMachine()
-            virtualMachine.delegate = self
-            self.managedVirtualMachine = ManagedVirtualMachine(machine: virtualMachine, config: launchConfiguration)
-
-            try await virtualMachine.start()
-
-            if launchConfiguration.waitForNetworking {
-                let ipAddress = try await vmManager.ipAddress(forVmWithName: launchConfiguration.handle)
-                Logger.helper.log("Startup complete – IP Address: \(ipAddress.debugDescription)")
-                self.status = .running(launchConfiguration, ipAddress)
-            } else {
-                Logger.helper.log("Startup in progress – skipped waiting for IP address per launch configuration")
-                self.status = .running(launchConfiguration, .any)
-            }
+            let newVM = try await startTask.value
+            newVM.machine.delegate = self
+            self.managedVirtualMachine = newVM
+            self.status = .running(launchConfiguration, newVM.ip)
         } catch {
             Logger.helper.error("Error launching VM: \(error.localizedDescription)")
             Logger.helper.error("Attempting Cleanup of \(launchConfiguration.handle)")
@@ -81,9 +72,30 @@ class VirtualMachineSlot: NSObject, ObservableObject {
     }
 
     @MainActor
+    private func createStartTask(launchConfiguration: LaunchConfiguration) -> Task<ManagedVirtualMachine, Error> {
+        Task {
+            let virtualMachine = try await launchConfiguration.setupVirtualMachine()
+            try await virtualMachine.start()
+
+            let ipAddress: IPv4Address
+            if launchConfiguration.waitForNetworking {
+                ipAddress = try await vmManager.ipAddress(forVmWithName: launchConfiguration.handle)
+                Logger.helper.log("Startup complete – IP Address: \(ipAddress.debugDescription)")
+            } else {
+                Logger.helper.log("Startup in progress – skipped waiting for IP address per launch configuration")
+                ipAddress = .any
+            }
+            return ManagedVirtualMachine(machine: virtualMachine, config: launchConfiguration, ip: ipAddress)
+        }
+    }
+
+    @MainActor
     func stopVirtualMachine() async throws {
         switch status {
-        case .starting, .running:
+        case .starting(_, let task):
+            task.cancel()
+            self.status = .stopping
+        case .running:
             self.status = .stopping
         default:
             break

--- a/Sources/hostmgr-helper/VirtualMachineSlot.swift
+++ b/Sources/hostmgr-helper/VirtualMachineSlot.swift
@@ -109,7 +109,7 @@ class VirtualMachineSlot: NSObject, ObservableObject {
         }
     }
 
-    private func cleanManagedVM(_ handle: String) async {
+    private func cleanManagedVm(_ handle: String) async {
         Logger.helper.log("Cleaning up VM \(handle).")
         do {
             try await vmManager.removeVM(name: handle)
@@ -124,11 +124,11 @@ class VirtualMachineSlot: NSObject, ObservableObject {
         case .starting(let config, let task):
             self.status = .stopping(config)
             task.cancel()
-            await cleanManagedVM(config.handle)
+            await cleanManagedVm(config.handle)
         case .running(let mvm, _):
             self.status = .stopping(mvm.config)
             await stopManagedVm(mvm)
-            await cleanManagedVM(mvm.handle)
+            await cleanManagedVm(mvm.handle)
         default:
             /// For all other states we do nothing.
             Logger.helper.debug("Stop called while state was \(status) - doing nothing.")
@@ -153,9 +153,9 @@ class VirtualMachineSlot: NSObject, ObservableObject {
             return config.handle == handle
         case .running(let mvm, _):
             Logger.helper.debug(
-                "Comparing \(mvm.config.handle) and \(handle)"
+                "Comparing \(mvm.handle) and \(handle)"
             )
-            return mvm.config.handle == handle
+            return mvm.handle == handle
         case .empty, .crashed:
             Logger.helper.debug(
                 "\(self.role) slot had no handle configured."

--- a/Sources/hostmgr-helper/VirtualMachineSlot.swift
+++ b/Sources/hostmgr-helper/VirtualMachineSlot.swift
@@ -17,7 +17,7 @@ class VirtualMachineSlot: NSObject, ObservableObject {
         }
     }
 
-    enum Status: Sendable {
+    enum State: Sendable {
         case empty
         case starting(LaunchConfiguration, Task<ManagedVirtualMachine, Error>)
         case running(ManagedVirtualMachine)
@@ -45,7 +45,7 @@ class VirtualMachineSlot: NSObject, ObservableObject {
     private let vmManager = VMManager()
 
     @Published
-    var status: Status = .empty
+    var state: State = .empty
 
     let role: Role
 
@@ -62,7 +62,7 @@ class VirtualMachineSlot: NSObject, ObservableObject {
 
         do {
             let startTask = Task { try await createManagedVm(launchConfiguration: launchConfiguration) }
-            self.status = .starting(launchConfiguration, startTask)
+            self.state = .starting(launchConfiguration, startTask)
             let newVM = try await startTask.value
             if startTask.isCancelled {
                 Logger.helper.debug("Start task was cancelled for \(newVM.handle).")
@@ -71,7 +71,7 @@ class VirtualMachineSlot: NSObject, ObservableObject {
 
             Logger.helper.log("Setting \(role.displayName) slot to running \(newVM.handle).")
             newVM.machine.delegate = self
-            self.status = .running(newVM)
+            self.state = .running(newVM)
         } catch {
             Logger.helper.error("Error launching VM: \(error.localizedDescription)")
             try? await stop(withError: error)
@@ -120,34 +120,34 @@ class VirtualMachineSlot: NSObject, ObservableObject {
     }
 
     func stop(withError error: Error? = nil) async throws {
-        Logger.helper.log("Stopping \(role.displayName) slot with current status \(status).")
-        switch status {
+        Logger.helper.log("Stopping \(role.displayName) slot with current status \(state).")
+        switch state {
         case .starting(let config, let task):
-            self.status = .stopping(config)
+            self.state = .stopping(config)
             task.cancel()
             await cleanManagedVm(config.handle)
         case .running(let mvm):
-            self.status = .stopping(mvm.config)
+            self.state = .stopping(mvm.config)
             await stopManagedVm(mvm)
             await cleanManagedVm(mvm.handle)
         default:
-            // For all other states we do nothing.
-            Logger.helper.debug("Stop called while state was \(status) - doing nothing.")
+            /// For all other states we do nothing.
+            Logger.helper.debug("Stop called while state was \(state) - doing nothing.")
             return
         }
 
         if let error {
             Logger.helper.error("Resetting slot with crashed state: \(error)")
-            self.status = .crashed(error)
+            self.state = .crashed(error)
         } else {
             Logger.helper.log("Resetting slot to empty state.")
-            self.status = .empty
+            self.state = .empty
         }
     }
 
     func isConfiguredForHandle(_ handle: String) -> Bool {
         let slotHandle: String?
-        switch status {
+        switch state {
         case .starting(let config, _), .stopping(let config):
             slotHandle = config.handle
         case .running(let mvm):
@@ -171,9 +171,9 @@ class VirtualMachineSlot: NSObject, ObservableObject {
 
     var isAvailable: Bool {
         Logger.helper.debug(
-            "Slot availability check: \(role.displayName) slot has \(status) status."
+            "Slot availability check: \(role.displayName) slot has \(state) status."
         )
-        switch self.status {
+        switch self.state {
         case .empty, .crashed: return true
         default: return false
         }

--- a/Sources/hostmgr-helper/VirtualMachineSlot.swift
+++ b/Sources/hostmgr-helper/VirtualMachineSlot.swift
@@ -20,7 +20,7 @@ class VirtualMachineSlot: NSObject, ObservableObject {
     enum Status: Sendable {
         case empty
         case starting(LaunchConfiguration, Task<ManagedVirtualMachine, Error>)
-        case running(ManagedVirtualMachine, IPv4Address)
+        case running(ManagedVirtualMachine)
         case stopping(LaunchConfiguration)
         case crashed(Error)
     }
@@ -72,7 +72,7 @@ class VirtualMachineSlot: NSObject, ObservableObject {
 
             newVM.machine.delegate = self
             Logger.helper.log("Setting \(role.displayName) slot to running \(newVM.handle).")
-            self.status = .running(newVM, newVM.ip)
+            self.status = .running(newVM)
         } catch {
             Logger.helper.error("Error launching VM: \(error.localizedDescription)")
             try? await stop(withError: error)
@@ -125,7 +125,7 @@ class VirtualMachineSlot: NSObject, ObservableObject {
             self.status = .stopping(config)
             task.cancel()
             await cleanManagedVm(config.handle)
-        case .running(let mvm, _):
+        case .running(let mvm):
             self.status = .stopping(mvm.config)
             await stopManagedVm(mvm)
             await cleanManagedVm(mvm.handle)
@@ -151,7 +151,7 @@ class VirtualMachineSlot: NSObject, ObservableObject {
                 "Comparing \(config.handle) and \(handle)"
             )
             return config.handle == handle
-        case .running(let mvm, _):
+        case .running(let mvm):
             Logger.helper.debug(
                 "Comparing \(mvm.handle) and \(handle)"
             )

--- a/Sources/hostmgr-helper/VirtualMachineSlot.swift
+++ b/Sources/hostmgr-helper/VirtualMachineSlot.swift
@@ -1,5 +1,5 @@
 import Foundation
-@preconcurrency import Virtualization
+import Virtualization
 import SwiftUI
 import OSLog
 import Network

--- a/Sources/hostmgr/commands/vm/VMClean.swift
+++ b/Sources/hostmgr/commands/vm/VMClean.swift
@@ -25,7 +25,7 @@ struct VMCleanCommand: AsyncParsableCommand {
         Console.info("Removing VMs not used since \(Format.date(cutoff, style: .short))")
 
         for image in unusedImages {
-            try await vmManager.removeVM(name: image.vmName)
+            try vmManager.removeVM(name: image.vmName)
             Console.success("Removed \(image.vmName)")
         }
 

--- a/Sources/libhostmgr/Platforms/VMManager.swift
+++ b/Sources/libhostmgr/Platforms/VMManager.swift
@@ -27,7 +27,8 @@ public struct VMManager {
     /// 
     public func stopVM(handle: String) async throws {
         try await HostmgrClient.stop(handle: handle)
-        try FileManager.default.removeItemIfExists(at: Paths.toWorkingAppleSiliconVM(named: handle))
+        // If the VM is ephemeral, clean it up.
+        try removeWorkingVM(handle: handle)
     }
 
     /// Immediately terminates all running VMs
@@ -38,11 +39,17 @@ public struct VMManager {
 
     /// Delete a local VM
     ///
-    public func removeVM(name: String) async throws {
+    public func removeVM(name: String) throws {
         try FileManager.default.removeItemIfExists(at: Paths.toAppleSiliconVM(named: name))
         try FileManager.default.removeItemIfExists(at: Paths.toArchivedVM(named: name))
         try FileManager.default.removeItemIfExists(at: Paths.toVMTemplate(named: name))
         try FileManager.default.removeItemIfExists(at: Paths.toWorkingAppleSiliconVM(named: name))
+    }
+
+    /// Delete a working, ephemeral VM.
+    ///
+    public func removeWorkingVM(handle: String) throws {
+        try FileManager.default.removeItemIfExists(at: Paths.toWorkingAppleSiliconVM(named: handle))
     }
 
     /// Unpack a packaged VM


### PR DESCRIPTION
## Attempts to fix
- #124
- #84

**Note:** This PR _does not_ attempt to fix an issue we're seeing with `hostmgr vm stop [handle]` becoming unresponsive. See #128.

## Description
- Turns the VM start call (start the VM and fetch an IP) into a Swift `Task` so that it has the option to be cancelled. This resolves an issue where a VM could've been stopped externally and the async start sequence returned to set the slot to a `.running` state.
- Removes state from `VirtualMachineSlot` by enforcing tighter coupling with the `Status` enum.

## Testing

### Steps from https://github.com/Automattic/hostmgr/pull/118

#### Prereqs

For each test confirm:
1. The bundle no longer exists in `/opt/ci/working-vm-images`
2. The VM no longer appears in the list when running `hostmgr vm list`
3. The VM no longer appears in the slot UI in the `hostmgr-helper` menu bar app
4. The `Virtual Machine Service for hostmgr-helper` process is killed by the OS
5. When the occupied slot count is less than 2, a new VM can start and the `Unable to launch more VMs – maximum reached` isn't shown.

#### Tests

1. Stop a VM by selecting the "Stop" button in the `hostmgr-helper` menu bar app
2. Stop a VM by running `hostmgr vm stop [handle]` in the command line
3. Stop a VM by killing the process using Activity Monitor (or the `kill` command)
4. Stop a VM by shutting down from within the VM via VNC or the `hostmgr-helper` View option

### Stopping a VM while it's starting

1. Start a VM and test stopping it at various points (immediately, after a few seconds, right before launch, right after launch)
2. Expect that `hostmgr vm list --location local` doesn't show the bundle ID, there's no VM process in Activity Monitor, the slot it occupied is available

**Note:** It's expected that if a VM is cancelled after getting an IP, but before [`waitForSSHServer`](https://github.com/Automattic/hostmgr/blob/47ddd938967661b57d19bce75564e634c5b59e85/Sources/libhostmgr/Platforms/VMManager.swift#L219) that the `hostmgr vm start` command will time out with a `sshConnectionTimeout`.