### PR TITLE
Improve the error thrown when the SSH connection times out

### DIFF
--- a/Sources/libhostmgr/CLI/HostmgrError.swift
+++ b/Sources/libhostmgr/CLI/HostmgrError.swift
@@ -20,6 +20,7 @@ public enum HostmgrError: Error, LocalizedError, Codable {
     case vmConfigurationFileMissing(URL)
     case invalidVMSourceImage(URL)
     case xpcError(String)
+    case sshAvailabilityTimeout
 
     public var errorDescription: String? {
         switch self {
@@ -64,6 +65,8 @@ public enum HostmgrError: Error, LocalizedError, Codable {
             return  "This Mac cannot create a VM from the disk image at \(url)"
         case .xpcError(let string):
             return string
+        case .sshAvailabilityTimeout:
+            return "Timeout while checking for the availability of the VM's SSH server"
         }
     }
 

--- a/Sources/libhostmgr/Platforms/VMManager.swift
+++ b/Sources/libhostmgr/Platforms/VMManager.swift
@@ -221,7 +221,7 @@ extension VMManager {
                 case .failed(let error):
                     continuation.resume(throwing: error)
                 case .cancelled:
-                    continuation.resume(throwing: CocoaError(.serviceRequestTimedOut))
+                    continuation.resume(throwing: HostmgrError.sshAvailabilityTimeout)
                 default:
                     break
                 }


### PR DESCRIPTION
Currently SSH timeouts throw this error to the `hostmgr` client:

`Error: The operation couldn't be completed. (Cocoa error 66562.)`

This PR updates this message to:

`Timeout while checking for the availability of the VM's SSH server`