### PR TITLE
Report error to Sentry if no VM slots are available

### DIFF
--- a/Sources/hostmgr-helper/HostMgrHelperApp.swift
+++ b/Sources/hostmgr-helper/HostMgrHelperApp.swift
@@ -56,6 +56,11 @@ struct HostMgrHelperApp: App {
         options.dsn = ProcessInfo.processInfo.environment["SENTRY_DSN"] ?? ""
         options.releaseName = libhostmgr.hostmgrVersion
         options.enableSwizzling = false
+        options.initialScope = { scope in
+            // Add the hostname to all Sentry events
+            scope.setTag(value: ProcessInfo.processInfo.hostName, key: "hostname")
+            return scope
+        }
 
         return options
     }()

--- a/Sources/hostmgr-helper/VMHost.swift
+++ b/Sources/hostmgr-helper/VMHost.swift
@@ -3,6 +3,7 @@ import Virtualization
 import libhostmgr
 import OSLog
 import Network
+import Sentry
 
 @MainActor
 class VMHost: NSObject, ObservableObject {
@@ -38,6 +39,10 @@ extension VMHost: HostmgrServerDelegate {
             return
         }
 
+        if Configuration.shared.reportNoSlotsErrorToSentry == true {
+            Logger.helper.debug("Reporting no slots error to Sentry")
+            SentrySDK.capture(error: HostmgrError.noVMSlotsAvailable)
+        }
         throw HostmgrError.noVMSlotsAvailable
     }
 

--- a/Sources/libhostmgr/Model/Configuration.swift
+++ b/Sources/libhostmgr/Model/Configuration.swift
@@ -62,6 +62,11 @@ public struct Configuration: Codable {
     public var hostReservedRAMBytes: UInt64 {
         hostReservedRAM ?? 1024 * 1024 * 2048 // Leave 2GB for the VM host
     }
+
+    // MARK: Various features
+
+    /// Should Sentry report an error if HostmgrError.noVMSlotsAvailable is thrown
+    public var reportNoSlotsErrorToSentry: Bool?
 }
 
 /// Accessor Helpers


### PR DESCRIPTION
## Description
- Adds a new `reportNoSlotsErrorToSentry` boolean to the configuration (read by `hostmgr.json`)
- Sends an error to Sentry about no slots being available if the option is enabled

## Testing

### Without new configuration (backwards compatibility, defaults to off)
1. Using the [standard hostmgr.json](https://github.com/Automattic/buildkite-ci/blob/trunk/src/agents/macos-hosts/resources/hostmgr.json) (A8c internal link) configured locally [as described in the README](https://github.com/Automattic/hostmgr?tab=readme-ov-file#installation), start `hostmgr-helper`
2. Attach a debugger to the `hostmgr-helper` process to view its log output
3. Start two VMs to populate the slots, then try to start a third one
4. **Expect**: No "Reporting no slots error to Sentry" message in the debug log output

### With new configuration
1. Using the [standard hostmgr.json](https://github.com/Automattic/buildkite-ci/blob/trunk/src/agents/macos-hosts/resources/hostmgr.json) (A8c internal link) configured locally [as described in the README](https://github.com/Automattic/hostmgr?tab=readme-ov-file#installation), add `"reportNoSlotsErrorToSentry": true` to it (be sure to add a comma after the previous value so it's valid JSON)
2. start `hostmgr-helper`
3. Attach a debugger to the `hostmgr-helper` process to view its log output
4. Start two VMs to populate the slots, then try to start a third one
5. **Expect**: "Reporting no slots error to Sentry" message in the debug log output

### Hostname tags
1. View [this error in Sentry](https://a8c.sentry.io/issues/6369699227/) and confirm that a system hostname is included in the Tags section.

**Note:** It's optional, but you can supply the `SENTRY_DSN` environment variable to `hostmgr-helper` to actually submit events to Sentry.