### PR TITLE
Attempt to fix VM stop call hang

### DIFF
--- a/Sources/hostmgr-helper/VirtualMachineSlot.swift
+++ b/Sources/hostmgr-helper/VirtualMachineSlot.swift
@@ -184,6 +184,8 @@ class VirtualMachineSlot: NSObject, ObservableObject {
         if vm.canStop {
             Logger.helper.debug("VM \(handle) claims it can be stopped.")
             do {
+                // An attempt to help with https://github.com/Automattic/hostmgr/issues/128
+                vm.networkDevices.forEach { $0.attachment = nil }
                 try await vm.stop()
                 Logger.helper.log("Stopped VM \(handle).")
             } catch {


### PR DESCRIPTION
## Description
This attempts to fix #128 by detaching networking devices before stopping the VM. I do not know exactly why this works, but I haven't been able to reproduce the hang by running [this script](https://github.com/Automattic/hostmgr/issues/128#issuecomment-2712163505) yet. 🤔 

## Testing

Create a bash script that starts a VM and immediately stops it:

```
#!/bin/sh

/opt/ci/bin/hostmgr vm start xcode-16.2-macos-14.7.1-v1 --handle cat && hostmgr vm stop cat
```

- Run `hostmgr-helper` via Xcode or LLDB to see the log output (easier to tell when it hangs)
- Run the bash script - if it hangs (and eventually times out), the VM stop hung. (the VM process will also exist in Activity Monitor)
- Comment out the change and re-run to see if there's a difference

Without the change I can typically reproduce a hang in ~10 tries. With the change I haven't been able to reproduce it yet (have attempted close to 50 times at this point).