### PR TITLE
Bump version to 0.54.2

### DIFF
--- a/Sources/libhostmgr/libhostmgr.swift
+++ b/Sources/libhostmgr/libhostmgr.swift
@@ -1,7 +1,7 @@
 import Foundation
 import OSLog
 
-public let hostmgrVersion = "0.54.0"
+public let hostmgrVersion = "0.54.2"
 
 public extension Logger {
     private static let subsystem = "com.automattic.hostmgr"


### PR DESCRIPTION
0.54.0 was tagged incorrectly locally, and 0.54.1 didn't include the version bump in `Sources/libhostmgr/libhostmgr.swift` 😅. This will get merged to `trunk` and then properly tagged.