### PR TITLE
Properly handle cleaning after stopping

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -53,6 +53,10 @@ let package = Package(
             ],
             swiftSettings: sharedSettings
         ),
+        .testTarget(
+            name: "hostmgr-helperTests",
+            dependencies: ["hostmgr-helper"]
+        ),
         .target(
             name: "libhostmgr",
             dependencies: [

--- a/Sources/hostmgr-helper/ManagedVirtualMachine.swift
+++ b/Sources/hostmgr-helper/ManagedVirtualMachine.swift
@@ -6,12 +6,18 @@ import libhostmgr
 
 @MainActor
 protocol ManagedVirtualMachine: Sendable {
+    /// The configuration used to launch the VM.
     var config: LaunchConfiguration { get }
+    /// The IP address of the VM.
     var ip: IPv4Address { get }
 
+    /// Starts the VM. Handles clean-up if anything goes wrong.
     func start() async throws
+    /// Stops the VM.
     func stop() async
+    /// Cleans the VM files.
     func clean()
+    /// Sets the slot to be a delegate for the VM.
     func setDelegate(_ delegate: VirtualMachineSlot)
 }
 
@@ -38,6 +44,7 @@ class VZManagedVirtualMachine: ManagedVirtualMachine {
             self.config = launchConfiguration
         } catch {
             // Note: This cleans ALL types of VMs that failed to start - even persistent.
+            Logger.helper.info("Cleaning all VM files for \(launchConfiguration.handle).")
             try? vmManager.removeVM(name: launchConfiguration.handle)
             throw error
         }
@@ -61,6 +68,7 @@ class VZManagedVirtualMachine: ManagedVirtualMachine {
             Logger.helper.error("Stopping VM \(config.handle) that was being launched: \(error)")
             await stop()
             // Note: This cleans ALL types of VMs that failed to start - even persistent.
+            Logger.helper.info("Cleaning all VM files for \(config.handle).")
             try? vmManager.removeVM(name: handle)
             throw error
         }

--- a/Sources/hostmgr-helper/ManagedVirtualMachine.swift
+++ b/Sources/hostmgr-helper/ManagedVirtualMachine.swift
@@ -56,8 +56,10 @@ class VZManagedVirtualMachine: ManagedVirtualMachine {
     func start() async throws {
         Logger.helper.log("Starting VM \(handle).")
         do {
+            try Task.checkCancellation()
             try await machine.start()
             if config.waitForNetworking {
+                try Task.checkCancellation()
                 self.ip = try await vmManager.ipAddress(forVmWithName: config.handle)
                 Logger.helper.log("Startup complete – IP Address: \(ip.debugDescription).")
             } else {

--- a/Sources/hostmgr-helper/ManagedVirtualMachine.swift
+++ b/Sources/hostmgr-helper/ManagedVirtualMachine.swift
@@ -56,11 +56,11 @@ class VZManagedVirtualMachine: ManagedVirtualMachine {
     func start() async throws {
         Logger.helper.log("Starting VM \(handle).")
         do {
-            try Task.checkCancellation()
             try await machine.start()
+            try Task.checkCancellation()
             if config.waitForNetworking {
-                try Task.checkCancellation()
                 self.ip = try await vmManager.ipAddress(forVmWithName: config.handle)
+                try Task.checkCancellation()
                 Logger.helper.log("Startup complete – IP Address: \(ip.debugDescription).")
             } else {
                 Logger.helper.log("Startup in progress – skipped waiting for IP address per launch configuration.")

--- a/Sources/hostmgr-helper/ManagedVirtualMachine.swift
+++ b/Sources/hostmgr-helper/ManagedVirtualMachine.swift
@@ -1,0 +1,112 @@
+import Foundation
+import Virtualization
+import OSLog
+import Network
+import libhostmgr
+
+@MainActor
+protocol ManagedVirtualMachine: Sendable {
+    var config: LaunchConfiguration { get }
+    var ip: IPv4Address { get }
+
+    func start() async throws
+    func stop() async
+    func clean()
+    func setDelegate(_ delegate: VirtualMachineSlot)
+}
+
+@MainActor
+class VZManagedVirtualMachine: ManagedVirtualMachine {
+    let machine: VZVirtualMachine
+    let config: LaunchConfiguration
+    var ip: IPv4Address = .any
+
+    private let vmManager = VMManager()
+
+    var handle: String {
+        config.handle
+    }
+
+    /// Creates a running VM inside a `ManagedVirtualMachine` configured by a `LaunchConfiguration`.
+    ///
+    /// If any errors occur this method will attempt to perform a cleanup.
+    /// - Parameter launchConfiguration: VM configuration.
+    init(launchConfiguration: LaunchConfiguration) throws {
+        Logger.helper.log("Creating VM \(launchConfiguration.handle).")
+        do {
+            self.machine = try launchConfiguration.setupVirtualMachine()
+            self.config = launchConfiguration
+        } catch {
+            // Note: This cleans ALL types of VMs that failed to start - even persistent.
+            try? vmManager.removeVM(name: launchConfiguration.handle)
+            throw error
+        }
+    }
+
+    /// Starts the VM and sets the IP if configured to wait for networking.
+    ///
+    /// If any errors occur after the VM was started, this method will attempt to stop the VM and perform a cleanup.
+    func start() async throws {
+        Logger.helper.log("Starting VM \(handle).")
+        do {
+            try await machine.start()
+            if config.waitForNetworking {
+                self.ip = try await vmManager.ipAddress(forVmWithName: config.handle)
+                Logger.helper.log("Startup complete – IP Address: \(ip.debugDescription).")
+            } else {
+                Logger.helper.log("Startup in progress – skipped waiting for IP address per launch configuration.")
+            }
+        } catch {
+            // Guarantee that the VM is stopped and cleaned before throwing.
+            Logger.helper.error("Stopping VM \(config.handle) that was being launched: \(error)")
+            await stop()
+            // Note: This cleans ALL types of VMs that failed to start - even persistent.
+            try? vmManager.removeVM(name: handle)
+            throw error
+        }
+    }
+
+    func setDelegate(_ delegate: VirtualMachineSlot) {
+        machine.delegate = delegate
+    }
+
+    /// Stops a VZVirtualMachine if it's in a state to be stopped.
+    /// - Parameters:
+    ///   - vm: VZVirtualMachine
+    ///   - handle: Handle to include in logs.
+    func stop() async {
+        Logger.helper.log("Stopping VM \(handle).")
+        // Quit responding to delegate methods.
+        machine.delegate = nil
+
+        if machine.canStop {
+            Logger.helper.debug("VM \(handle) claims it can be stopped.")
+            do {
+                // An attempt to help with https://github.com/Automattic/hostmgr/issues/128
+                machine.networkDevices.forEach { $0.attachment = nil }
+                try await machine.stop()
+                Logger.helper.log("Stopped VM \(handle).")
+            } catch {
+                Logger.helper.error("Failure when stopping VM: \(error)")
+            }
+        }
+    }
+
+    /// Used internally by the class to clean ephemeral VMs. This may be called because of an
+    /// "external" event via the `VZVirtualMachineDelegate` calls, or stopping from the menu bar.
+    /// 
+    /// VMs typically stop via the `hostmgr stop` command which handles cleanup on its own.
+    /// Only ephemeral VM files are removed.
+    /// - Parameters:
+    ///   - handle: Handle used to identify the bundle on disk.
+    func clean() {
+        Logger.helper.log("Cleaning up VM \(handle).")
+        do {
+            // Remove working (ephemeral) VMs only.
+            try vmManager.removeWorkingVM(handle: config.handle)
+            Logger.helper.log("Cleaned up VM \(handle).")
+        } catch {
+            Logger.helper.error("Failure when removing VM files: \(error)")
+        }
+    }
+}

--- a/Sources/hostmgr-helper/VM List/States/RunningVMListItem.swift
+++ b/Sources/hostmgr-helper/VM List/States/RunningVMListItem.swift
@@ -29,7 +29,7 @@ struct RunningVMListItem: View {
 
     func shutdown() {
         Task {
-            try await slot.stop()
+            try await slot.stop(clean: true)
         }
     }
 

--- a/Sources/hostmgr-helper/VM List/VMListItem.swift
+++ b/Sources/hostmgr-helper/VM List/VMListItem.swift
@@ -8,9 +8,9 @@ struct VMListItem: View {
     var body: some View {
         switch slot.state {
         case .empty: EmptyVMListItem(slot: slot)
-        case .starting(let launchConfiguration, _):
+        case .starting(let mvm, _):
             PendingVMListItem(
-                launchConfiguration: launchConfiguration,
+                launchConfiguration: mvm.config,
                 slot: slot
             )
         case .running(let virtualMachine):

--- a/Sources/hostmgr-helper/VMHost.swift
+++ b/Sources/hostmgr-helper/VMHost.swift
@@ -29,13 +29,15 @@ extension VMHost: HostmgrServerDelegate {
 
         if self.primaryVMSlot.isAvailable {
             Logger.helper.log("Using Primary Slot")
-            try await primaryVMSlot.start(launchConfiguration: launchConfiguration)
+            let vm = try VZManagedVirtualMachine(launchConfiguration: launchConfiguration)
+            try await primaryVMSlot.start(managedVirtualMachine: vm)
             return
         }
 
         if self.secondaryVMSlot.isAvailable {
             Logger.helper.log("Using Secondary Slot")
-            try await secondaryVMSlot.start(launchConfiguration: launchConfiguration)
+            let vm = try VZManagedVirtualMachine(launchConfiguration: launchConfiguration)
+            try await secondaryVMSlot.start(managedVirtualMachine: vm)
             return
         }
 

--- a/Sources/hostmgr-helper/VMWindow.swift
+++ b/Sources/hostmgr-helper/VMWindow.swift
@@ -13,7 +13,7 @@ struct VMWindowContent: View {
         switch vmSlot.state {
         case .empty:  Text("VM not running")
         case .starting: ProgressView()
-        case .running(let virtualMachine): VirtualMachineDisplayView(virtualMachine: virtualMachine.machine)
+        case .running(let virtualMachine): VirtualMachineDisplayView(virtualMachine: virtualMachine)
         .onAppear {
             NSApp.setActivationPolicy(.regular)
             NSApp.activate(ignoringOtherApps: true)

--- a/Sources/hostmgr-helper/VirtualMachineDisplayView.swift
+++ b/Sources/hostmgr-helper/VirtualMachineDisplayView.swift
@@ -4,11 +4,12 @@ import Virtualization
 struct VirtualMachineDisplayView: NSViewRepresentable {
     typealias NSViewType = VZVirtualMachineView
 
-    let virtualMachine: VZVirtualMachine?
+    let virtualMachine: ManagedVirtualMachine
 
     func makeNSView(context: Context) -> VZVirtualMachineView {
         let view = VZVirtualMachineView()
-        view.virtualMachine = virtualMachine
+        view.virtualMachine = (virtualMachine as? VZManagedVirtualMachine)?.machine
+
         if #available(macOS 14.0, *) {
             view.automaticallyReconfiguresDisplay = true
         }

--- a/Sources/hostmgr-helper/VirtualMachineSlot.swift
+++ b/Sources/hostmgr-helper/VirtualMachineSlot.swift
@@ -32,11 +32,16 @@ class VirtualMachineSlot: NSObject, ObservableObject {
             let startTask = Task { try await managedVirtualMachine.start() }
             try state.transitionTo(.starting(managedVirtualMachine, startTask))
             try await startTask.value
+            // If the start task caught a cancellation (e.g. during a Task.sleep() call), it will throw.
+            // We also want to check for the cancellation here in case startup completed.
+            if startTask.isCancelled {
+                throw Errors.vmStartCancelled
+            }
 
             Logger.helper.log("Setting \(role.displayName) slot to running \(managedVirtualMachine.config.handle).")
             managedVirtualMachine.setDelegate(self)
             try state.transitionTo(.running(managedVirtualMachine))
-        } catch is CancellationError {
+        } catch is CancellationError, Errors.vmStartCancelled {
             // We're already transitioning from Starting -> Stopping by an external call, so
             // we just throw.
             Logger.helper.debug("Start task was cancelled for \(managedVirtualMachine.config.handle).")
@@ -61,9 +66,11 @@ class VirtualMachineSlot: NSObject, ObservableObject {
             "Stopping \(clean ? "and cleaning " : "")\(role.displayName) slot with current status \(state)."
         )
         switch state {
-        case .starting(let config, let task):
-            try state.transitionTo(.stopping(config))
+        case .starting(let mvm, let task):
+            try state.transitionTo(.stopping(mvm))
             task.cancel()
+            await mvm.stop()
+            if clean { mvm.clean() }
         case .running(let mvm):
             try state.transitionTo(.stopping(mvm))
             await mvm.stop()

--- a/Sources/hostmgr-helper/VirtualMachineSlot.swift
+++ b/Sources/hostmgr-helper/VirtualMachineSlot.swift
@@ -159,9 +159,12 @@ class VirtualMachineSlot: NSObject, ObservableObject {
             self.state.transitionTo(newState: .stopping(mvm.config))
             await stopVm(mvm.machine, handle: mvm.handle)
             if clean { cleanVm(handle: mvm.handle) }
-        default:
-            Logger.helper.error("Stop called while state was \(state).")
+        case.stopping:
+            Logger.helper.error("Error: Stop was called while stopping.")
             throw Errors.invalidStopState
+        case .empty, .crashed:
+            Logger.helper.info("Stop called while state was \(state).")
+            return
         }
 
         if let error {

--- a/Sources/hostmgr-helper/VirtualMachineSlot.swift
+++ b/Sources/hostmgr-helper/VirtualMachineSlot.swift
@@ -75,7 +75,7 @@ class VirtualMachineSlot: NSObject, ObservableObject {
             try state.transitionTo(.stopping(mvm))
             await mvm.stop()
             if clean { mvm.clean() }
-        case.stopping:
+        case .stopping:
             Logger.helper.error("Error: Stop was called while stopping.")
             throw Errors.invalidStopState
         case .empty, .crashed:

--- a/Sources/hostmgr-helper/VirtualMachineSlot.swift
+++ b/Sources/hostmgr-helper/VirtualMachineSlot.swift
@@ -134,18 +134,21 @@ class VirtualMachineSlot: NSObject, ObservableObject {
             Logger.helper.error("Error launching VM: \(error.localizedDescription)")
             // We only call stop to reset the slot state - VM stopping and cleanup already occurred.
             try? await stop(withError: error)
+
             throw error
         }
     }
 
     /// Puts the slot into a stopped state if it's a valid request.
     ///
-    /// - This method does not clean up stopped VMs.
     /// - This method throws an error if trying to stop in a state other than `.starting` and `.running`.
     /// - Parameters:
     ///   - error: Error to include if the slot is stopping because of an error.
-    func stop(withError error: Error? = nil) async throws {
-        Logger.helper.log("Stopping \(role.displayName) slot with current status \(state).")
+    ///   - clean: If VM files should also be cleaned.
+    func stop(withError error: Error? = nil, clean: Bool = false) async throws {
+        Logger.helper.log(
+            "Stopping \(clean ? "and cleaning " : "")\(role.displayName) slot with current status \(state)."
+        )
         switch state {
         case .starting(let config, let task):
             // MARK: Starting -> Stopping
@@ -155,6 +158,7 @@ class VirtualMachineSlot: NSObject, ObservableObject {
             // MARK: Running -> Stopping
             self.state.transitionTo(newState: .stopping(mvm.config))
             await stopVm(mvm.machine, handle: mvm.handle)
+            if clean { cleanVm(handle: mvm.handle) }
         default:
             Logger.helper.error("Stop called while state was \(state).")
             throw Errors.invalidStopState
@@ -232,6 +236,10 @@ class VirtualMachineSlot: NSObject, ObservableObject {
         }
     }
 
+    /// Stops a VZVirtualMachine if it's in a state to be stopped.
+    /// - Parameters:
+    ///   - vm: VZVirtualMachine
+    ///   - handle: Handle to include in logs.
     private func stopVm(_ vm: VZVirtualMachine, handle: String) async {
         Logger.helper.log("Stopping VM \(handle).")
         // Quit responding to delegate methods.
@@ -249,24 +257,15 @@ class VirtualMachineSlot: NSObject, ObservableObject {
             }
         }
     }
-}
 
-// MARK: VZVirtualMachineDelegate conformance
-extension VirtualMachineSlot: VZVirtualMachineDelegate {
-    /// Used internally by the class when it needs to stop the VM and run the clean up step afterwards. This may
-    /// be called because of an "external" event via the `VZVirtualMachineDelegate` calls.
+    /// Used internally by the class to clean ephemeral VMs. This may be called because of an
+    /// "external" event via the `VZVirtualMachineDelegate` calls, or stopping from the menu bar.
     ///
     /// VMs typically stop via the `hostmgr stop` command which handles cleanup on its own.
     /// Only ephemeral VM files are removed.
     /// - Parameters:
-    ///   - error: Error to include if the slot is stopping because of an error.
-    private func stopAndClean(withError error: Error? = nil) async throws {
-        Logger.helper.log("Stopping and cleaning \(role.displayName).")
-        try await stop(withError: error)
-        guard let handle = state.handle else {
-            return
-        }
-
+    ///   - handle: Handle used to identify the bundle on disk.
+    private func cleanVm(handle: String) {
         Logger.helper.log("Cleaning up VM \(handle).")
         do {
             // Remove working (ephemeral) VMs only.
@@ -276,19 +275,22 @@ extension VirtualMachineSlot: VZVirtualMachineDelegate {
             Logger.helper.error("Failure when removing VM files: \(error)")
         }
     }
+}
 
+// MARK: VZVirtualMachineDelegate conformance
+extension VirtualMachineSlot: VZVirtualMachineDelegate {
     /// Called when a VM is stopped gracefully.
     nonisolated func guestDidStop(_ virtualMachine: VZVirtualMachine) {
         Logger.helper.log("Virtual Machine Stopped")
         Task {
-            try await stopAndClean()
+            try await stop(clean: true)
         }
     }
 
     nonisolated func virtualMachine(_ virtualMachine: VZVirtualMachine, didStopWithError error: Error) {
         Logger.helper.error("Virtual Machine Crashed: \(error.localizedDescription)")
         Task {
-            try await stopAndClean(withError: error)
+            try await stop(withError: error, clean: true)
         }
     }
 
@@ -299,7 +301,7 @@ extension VirtualMachineSlot: VZVirtualMachineDelegate {
     ) {
         Logger.helper.error("Network attachment was disconnected: \(error.localizedDescription)")
         Task {
-            try await stopAndClean()
+            try await stop(clean: true)
         }
     }
 }

--- a/Sources/hostmgr-helper/VirtualMachineSlot.swift
+++ b/Sources/hostmgr-helper/VirtualMachineSlot.swift
@@ -7,7 +7,109 @@ import libhostmgr
 
 @MainActor
 class VirtualMachineSlot: NSObject, ObservableObject {
+    @Published
+    var state: State = .empty
 
+    let role: Role
+
+    init(role: Role) {
+        self.role = role
+    }
+
+    /// Requests that the slot go to a running state with a `ManagedVirtualMachine`
+    ///
+    /// This method throws an error if trying to start in an invalid state, or if there was an error
+    /// starting the VM.
+    /// - Parameter managedVirtualMachine: A type that conforms to `ManagedVirtualMachine`.
+    func start(managedVirtualMachine: ManagedVirtualMachine) async throws {
+        Logger.helper.log("Launch request for \(managedVirtualMachine.config.handle).")
+
+        guard isAvailable else {
+            throw Errors.invalidStartState
+        }
+
+        do {
+            let startTask = Task { try await managedVirtualMachine.start() }
+            try state.transitionTo(.starting(managedVirtualMachine, startTask))
+            try await startTask.value
+
+            Logger.helper.log("Setting \(role.displayName) slot to running \(managedVirtualMachine.config.handle).")
+            managedVirtualMachine.setDelegate(self)
+            try state.transitionTo(.running(managedVirtualMachine))
+        } catch is CancellationError {
+            // We're already transitioning from Starting -> Stopping by an external call, so
+            // we just throw.
+            Logger.helper.debug("Start task was cancelled for \(managedVirtualMachine.config.handle).")
+            throw Errors.vmStartCancelled
+        } catch {
+            // We only call stop to reset the slot state - VM stopping and cleanup already occurred
+            // in the ManagedVirtualMachine.
+            Logger.helper.error("Error launching VM: \(error.localizedDescription)")
+            try? await stop(withError: error)
+            throw error
+        }
+    }
+
+    /// Puts the slot into a stopped state if it's a valid request.
+    ///
+    /// - This method throws an error if trying to stop in a state other than `.starting` and `.running`.
+    /// - Parameters:
+    ///   - error: Error to include if the slot is stopping because of an error.
+    ///   - clean: If VM files should also be cleaned.
+    func stop(withError error: Error? = nil, clean: Bool = false) async throws {
+        Logger.helper.log(
+            "Stopping \(clean ? "and cleaning " : "")\(role.displayName) slot with current status \(state)."
+        )
+        switch state {
+        case .starting(let config, let task):
+            try state.transitionTo(.stopping(config))
+            task.cancel()
+        case .running(let mvm):
+            try state.transitionTo(.stopping(mvm))
+            await mvm.stop()
+            if clean { mvm.clean() }
+        case.stopping:
+            Logger.helper.error("Error: Stop was called while stopping.")
+            throw Errors.invalidStopState
+        case .empty, .crashed:
+            Logger.helper.info("Stop called while state was \(state).")
+            return
+        }
+
+        if let error {
+            Logger.helper.error("Resetting slot with crashed state: \(error)")
+            try state.transitionTo(.crashed(error))
+        } else {
+            Logger.helper.log("Resetting slot to empty state.")
+            try state.transitionTo(.empty)
+        }
+    }
+
+    func isConfiguredForHandle(_ handle: String) -> Bool {
+        guard let slotHandle = state.handle else {
+            Logger.helper.debug(
+                "\(role.displayName) slot had no handle configured."
+            )
+            return false
+        }
+
+        Logger.helper.debug(
+            "Comparing \(slotHandle) and \(handle)."
+        )
+        return slotHandle == handle
+    }
+
+    /// If the slot is available.
+    var isAvailable: Bool {
+        switch state {
+        case .empty, .crashed: return true
+        default: return false
+        }
+    }
+}
+
+// MARK: - Types
+extension VirtualMachineSlot {
     enum Role: String, Codable {
         case primary
         case secondary
@@ -17,25 +119,41 @@ class VirtualMachineSlot: NSObject, ObservableObject {
         }
     }
 
-    enum State: Sendable {
+    @MainActor
+    enum State: Equatable {
         case empty
-        case starting(LaunchConfiguration, Task<ManagedVirtualMachine, Error>)
+        case starting(ManagedVirtualMachine, Task<Void, Error>)
         case running(ManagedVirtualMachine)
-        case stopping(LaunchConfiguration)
+        case stopping(ManagedVirtualMachine)
         case crashed(Error)
+
+        nonisolated static func == (lhs: State, rhs: State) -> Bool {
+            switch (lhs, rhs) {
+            case (.empty, .empty):
+                return true
+            case (.starting, .starting):
+                return true
+            case (.running, .running):
+                return true
+            case (.stopping, .stopping):
+                return true
+            case (.crashed, .crashed):
+                return true
+            default:
+                return false
+            }
+        }
 
         var handle: String? {
             switch self {
-            case .starting(let config, _), .stopping(let config):
-                return config.handle
-            case .running(let mvm):
-                return mvm.handle
+            case .starting(let mvm, _), .running(let mvm), .stopping(let mvm):
+                return mvm.config.handle
             case .empty, .crashed:
                 return nil
             }
         }
 
-        mutating func transitionTo(newState: State) {
+        mutating func transitionTo(_ newState: State) throws {
             switch (self, newState) {
             case (.empty, .starting):
                 // Starting a new VM from a clean state.
@@ -61,10 +179,10 @@ class VirtualMachineSlot: NSObject, ObservableObject {
             default:
                 // Invalid transition.
                 Logger.helper.error("An invalid state change was called from \(self) to \(newState).")
-                return
+                throw Errors.invalidStateTransition
             }
 
-            Logger.helper.info("Slot state transitioned from \(self) to \(newState).")
+            Logger.helper.info("Slot state transitioned from \(self) to \(newState)")
             self = newState
         }
     }
@@ -74,225 +192,26 @@ class VirtualMachineSlot: NSObject, ObservableObject {
         case invalidStartState
         /// The slot was asked to stop a VM when it was already stopping
         case invalidStopState
+        /// The slot tried to transition to an invalid state.
+        case invalidStateTransition
         /// The VM was stopped while starting.
         case vmStartCancelled
     }
-
-    struct ManagedVirtualMachine {
-        let machine: VZVirtualMachine
-        let config: LaunchConfiguration
-        let ip: IPv4Address
-
-        var handle: String {
-            config.handle
-        }
-    }
-
-    private let vmManager = VMManager()
-
-    @Published
-    var state: State = .empty
-
-    let role: Role
-
-    init(role: Role) {
-        self.role = role
-    }
-
-    /// Requests that the slot go to a running state with a VM configured by `launchConfiguration`.
-    ///
-    /// This method throws an error if trying to start in an invalid state, or if there was an error
-    /// initializing the VM.
-    /// - Parameter launchConfiguration: VM configuration.
-    func start(launchConfiguration: LaunchConfiguration) async throws {
-        Logger.helper.log("Launch request for \(launchConfiguration.handle).")
-
-        guard isAvailable else {
-            throw Errors.invalidStartState
-        }
-
-        do {
-            // MARK: Empty / Crashed -> Starting
-            let startTask = Task { try await createManagedVm(launchConfiguration: launchConfiguration) }
-            self.state.transitionTo(newState: .starting(launchConfiguration, startTask))
-            let newVM = try await startTask.value
-            // stop() was called while the VM was starting.
-            if startTask.isCancelled { throw Errors.vmStartCancelled }
-
-            // MARK: Starting -> Running
-            Logger.helper.log("Setting \(role.displayName) slot to running \(newVM.handle).")
-            newVM.machine.delegate = self
-
-            self.state.transitionTo(newState: .running(newVM))
-        } catch Errors.vmStartCancelled {
-            // We're already transitioning from Starting -> Stopping by an external call.
-            Logger.helper.debug("Start task was cancelled for \(launchConfiguration.handle).")
-
-            throw Errors.vmStartCancelled
-        } catch {
-            // MARK: Starting -> Stopping
-            Logger.helper.error("Error launching VM: \(error.localizedDescription)")
-            // We only call stop to reset the slot state - VM stopping and cleanup already occurred.
-            try? await stop(withError: error)
-
-            throw error
-        }
-    }
-
-    /// Puts the slot into a stopped state if it's a valid request.
-    ///
-    /// - This method throws an error if trying to stop in a state other than `.starting` and `.running`.
-    /// - Parameters:
-    ///   - error: Error to include if the slot is stopping because of an error.
-    ///   - clean: If VM files should also be cleaned.
-    func stop(withError error: Error? = nil, clean: Bool = false) async throws {
-        Logger.helper.log(
-            "Stopping \(clean ? "and cleaning " : "")\(role.displayName) slot with current status \(state)."
-        )
-        switch state {
-        case .starting(let config, let task):
-            // MARK: Starting -> Stopping
-            self.state.transitionTo(newState: .stopping(config))
-            task.cancel()
-        case .running(let mvm):
-            // MARK: Running -> Stopping
-            self.state.transitionTo(newState: .stopping(mvm.config))
-            await stopVm(mvm.machine, handle: mvm.handle)
-            if clean { cleanVm(handle: mvm.handle) }
-        case.stopping:
-            Logger.helper.error("Error: Stop was called while stopping.")
-            throw Errors.invalidStopState
-        case .empty, .crashed:
-            Logger.helper.info("Stop called while state was \(state).")
-            return
-        }
-
-        if let error {
-            // MARK: Stopping -> Crashed
-            Logger.helper.error("Resetting slot with crashed state: \(error)")
-            self.state.transitionTo(newState: .crashed(error))
-        } else {
-            // MARK: Stopping -> Empty
-            Logger.helper.log("Resetting slot to empty state.")
-            self.state.transitionTo(newState: .empty)
-        }
-    }
-
-    func isConfiguredForHandle(_ handle: String) -> Bool {
-        guard let slotHandle = state.handle else {
-            Logger.helper.debug(
-                "\(role.displayName) slot had no handle configured."
-            )
-            return false
-        }
-
-        Logger.helper.debug(
-            "Comparing \(slotHandle) and \(handle)."
-        )
-        return slotHandle == handle
-    }
-
-    var isAvailable: Bool {
-        Logger.helper.debug(
-            "Slot availability check: \(role.displayName) slot has \(state) status."
-        )
-
-        switch self.state {
-        case .empty, .crashed: return true
-        default: return false
-        }
-    }
-
-    /// Creates a running VM inside a `ManagedVirtualMachine` configured by a `LaunchConfiguration`.
-    ///
-    /// If any errors occur after the VM was started, this method will attempt to stop the VM and perform a cleanup.
-    /// - Parameter launchConfiguration: VM configuration.
-    /// - Returns: A `ManagedVirtualMachine` containing a running VM.
-    private func createManagedVm(launchConfiguration: LaunchConfiguration) async throws -> ManagedVirtualMachine {
-        Logger.helper.log("Creating VM \(launchConfiguration.handle).")
-        // Maintain a reference to the new VM for clean up purposes.
-        var newVM: VZVirtualMachine?
-
-        do {
-            let virtualMachine = try await launchConfiguration.setupVirtualMachine()
-            newVM = virtualMachine
-            try await virtualMachine.start()
-
-            let ipAddress: IPv4Address
-            if launchConfiguration.waitForNetworking {
-                ipAddress = try await vmManager.ipAddress(forVmWithName: launchConfiguration.handle)
-                Logger.helper.log("Startup complete – IP Address: \(ipAddress.debugDescription).")
-            } else {
-                Logger.helper.log("Startup in progress – skipped waiting for IP address per launch configuration.")
-                ipAddress = .any
-            }
-            return ManagedVirtualMachine(machine: virtualMachine, config: launchConfiguration, ip: ipAddress)
-        } catch {
-            // Guarantee that the VM is stopped and cleaned before throwing.
-            Logger.helper.error("Stopping VM \(launchConfiguration.handle) that was being launched: \(error)")
-            if let newVM {
-                await stopVm(newVM, handle: launchConfiguration.handle)
-            }
-            // Note: This cleans ALL types of VMs that failed to start - even persistent
-            try? vmManager.removeVM(name: launchConfiguration.handle)
-            throw error
-        }
-    }
-
-    /// Stops a VZVirtualMachine if it's in a state to be stopped.
-    /// - Parameters:
-    ///   - vm: VZVirtualMachine
-    ///   - handle: Handle to include in logs.
-    private func stopVm(_ vm: VZVirtualMachine, handle: String) async {
-        Logger.helper.log("Stopping VM \(handle).")
-        // Quit responding to delegate methods.
-        vm.delegate = nil
-
-        if vm.canStop {
-            Logger.helper.debug("VM \(handle) claims it can be stopped.")
-            do {
-                // An attempt to help with https://github.com/Automattic/hostmgr/issues/128
-                vm.networkDevices.forEach { $0.attachment = nil }
-                try await vm.stop()
-                Logger.helper.log("Stopped VM \(handle).")
-            } catch {
-                Logger.helper.error("Failure when stopping VM: \(error)")
-            }
-        }
-    }
-
-    /// Used internally by the class to clean ephemeral VMs. This may be called because of an
-    /// "external" event via the `VZVirtualMachineDelegate` calls, or stopping from the menu bar.
-    ///
-    /// VMs typically stop via the `hostmgr stop` command which handles cleanup on its own.
-    /// Only ephemeral VM files are removed.
-    /// - Parameters:
-    ///   - handle: Handle used to identify the bundle on disk.
-    private func cleanVm(handle: String) {
-        Logger.helper.log("Cleaning up VM \(handle).")
-        do {
-            // Remove working (ephemeral) VMs only.
-            try vmManager.removeWorkingVM(handle: handle)
-            Logger.helper.log("Cleaned up VM \(handle).")
-        } catch {
-            Logger.helper.error("Failure when removing VM files: \(error)")
-        }
-    }
 }
 
-// MARK: VZVirtualMachineDelegate conformance
+// MARK: - VZVirtualMachineDelegate conformance
 extension VirtualMachineSlot: VZVirtualMachineDelegate {
     /// Called when a VM is stopped gracefully.
     nonisolated func guestDidStop(_ virtualMachine: VZVirtualMachine) {
         Logger.helper.log("Virtual Machine Stopped")
-        Task {
+        Task { @MainActor in
             try await stop(clean: true)
         }
     }
 
     nonisolated func virtualMachine(_ virtualMachine: VZVirtualMachine, didStopWithError error: Error) {
         Logger.helper.error("Virtual Machine Crashed: \(error.localizedDescription)")
-        Task {
+        Task { @MainActor in
             try await stop(withError: error, clean: true)
         }
     }
@@ -303,7 +222,7 @@ extension VirtualMachineSlot: VZVirtualMachineDelegate {
         attachmentWasDisconnectedWithError error: Error
     ) {
         Logger.helper.error("Network attachment was disconnected: \(error.localizedDescription)")
-        Task {
+        Task { @MainActor in
             try await stop(clean: true)
         }
     }

--- a/Sources/libhostmgr/VM/LaunchConfiguration.swift
+++ b/Sources/libhostmgr/VM/LaunchConfiguration.swift
@@ -97,7 +97,7 @@ Persistence: \(persistent)
         }
     }
 
-    public func setupVirtualMachine() async throws -> VZVirtualMachine {
+    public func setupVirtualMachine() throws -> VZVirtualMachine {
         let sourceBundle = try VMBundle(at: vmSourcePath)
         let bundle = self.persistent
             ? sourceBundle

--- a/Tests/hostmgr-helperTests/TestHelpers.swift
+++ b/Tests/hostmgr-helperTests/TestHelpers.swift
@@ -1,0 +1,60 @@
+import Foundation
+import Network
+
+import libhostmgr
+@testable import hostmgr_helper
+
+@MainActor
+class MockManagedVirtualMachine: ManagedVirtualMachine {
+    let config: LaunchConfiguration
+    let ip: IPv4Address = .any
+    let handle: String = "test-handle"
+
+    enum State {
+        case started
+        case stopped
+    }
+
+    enum Errors: Error {
+        case crashedAtStart
+        case genericError
+    }
+
+    var state: State = .stopped
+
+    // used to simulate an error thrown when starting
+    var shouldCrashAtStart = false
+    // whether the VM was asked to clean
+    var cleaned = false
+    // if the delegate has been set
+    var delegateSet = false
+    // a delay can be added to test concurrency races
+    var startupDelay: Duration = .seconds(0)
+    var stopDelay: Duration = .seconds(0)
+
+    init(name: String, handle: String) {
+        config = LaunchConfiguration(name: name, handle: handle)
+    }
+
+    func start() async throws {
+        try await Task.sleep(for: startupDelay)
+        if shouldCrashAtStart {
+            throw Errors.crashedAtStart
+        }
+        self.state = .started
+    }
+
+    func stop() async {
+        try? await Task.sleep(for: stopDelay)
+        self.state = .stopped
+    }
+
+    func clean() {
+        self.cleaned = true
+    }
+
+    func setDelegate(_ delegate: hostmgr_helper.VirtualMachineSlot) {
+        self.delegateSet = true
+    }
+
+}

--- a/Tests/hostmgr-helperTests/VirtualMachineSlotTests.swift
+++ b/Tests/hostmgr-helperTests/VirtualMachineSlotTests.swift
@@ -1,0 +1,159 @@
+import XCTest
+import libhostmgr
+@testable import hostmgr_helper
+
+@MainActor
+class VirtualMachineSlotTests: XCTestCase {
+    var managedVirtualMachine: MockManagedVirtualMachine!
+    var slot: VirtualMachineSlot!
+
+    override func setUp() async throws {
+        managedVirtualMachine = MockManagedVirtualMachine(name: "test-name", handle: "test-handle")
+        slot = VirtualMachineSlot(role: .primary)
+    }
+
+    func testStartingAndStoppingVM() async throws {
+        try await slot.start(managedVirtualMachine: managedVirtualMachine)
+        XCTAssertEqual(managedVirtualMachine.state, .started)
+        XCTAssertEqual(slot.state, .running(managedVirtualMachine))
+        try await slot.stop()
+        XCTAssertEqual(slot.state, .empty)
+        XCTAssertEqual(managedVirtualMachine.state, .stopped)
+        XCTAssertEqual(managedVirtualMachine.cleaned, false)
+    }
+
+    func testCancelledStart() async throws {
+        // Make the startup a little slower so we can sneak a stop() call in
+        managedVirtualMachine.startupDelay = .seconds(5)
+
+        await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask { @MainActor in
+                do {
+                    try await self.slot.start(managedVirtualMachine: self.managedVirtualMachine)
+                } catch VirtualMachineSlot.Errors.vmStartCancelled {
+                    // Expected
+                } catch {
+                    XCTFail(error.localizedDescription)
+                }
+            }
+
+            group.addTask { @MainActor in
+                // Give the slot a moment to switch to .starting
+                try await Task.sleep(for: .seconds(2))
+                switch self.slot.state {
+                case .starting: break
+                default: XCTFail("Expected to be in the starting state.")
+                }
+                // This should stop a starting a VM, throwing the expected error.
+                try await self.slot.stop()
+            }
+        }
+
+        XCTAssertEqual(slot.state, .empty)
+        XCTAssertEqual(managedVirtualMachine.state, .stopped)
+    }
+
+    func testCallingStartWhileUnavailable() async throws {
+        let newManagedVirtualMachine = MockManagedVirtualMachine(name: "new-name", handle: "new-handle")
+        try await self.slot.start(managedVirtualMachine: self.managedVirtualMachine)
+
+        XCTAssertEqual(self.slot.isAvailable, false)
+        do {
+            try await self.slot.start(managedVirtualMachine: newManagedVirtualMachine)
+        } catch VirtualMachineSlot.Errors.invalidStartState {
+            // Expected
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+
+        XCTAssertEqual(managedVirtualMachine.state, .started)
+        XCTAssertTrue(slot.isConfiguredForHandle(managedVirtualMachine.handle))
+        XCTAssertEqual(newManagedVirtualMachine.state, .stopped)
+    }
+
+    func testSlotReturnsToEmptyState() async throws {
+        try await slot.start(managedVirtualMachine: managedVirtualMachine)
+        try await slot.stop()
+        XCTAssertEqual(slot.state, .empty)
+    }
+
+    func testSlotReturnsToCrashedState() async throws {
+        managedVirtualMachine.shouldCrashAtStart = true
+        try? await slot.start(managedVirtualMachine: managedVirtualMachine)
+        XCTAssertEqual(slot.state, .crashed(MockManagedVirtualMachine.Errors.crashedAtStart))
+    }
+
+    func testCallingStopWithoutClean() async throws {
+        try await slot.start(managedVirtualMachine: managedVirtualMachine)
+        try await slot.stop(clean: false)
+        XCTAssertEqual(managedVirtualMachine.state, .stopped)
+        XCTAssertEqual(managedVirtualMachine.cleaned, false)
+    }
+
+    func testCallingStopAndClean() async throws {
+        try await slot.start(managedVirtualMachine: managedVirtualMachine)
+        try await slot.stop(clean: true)
+        XCTAssertEqual(managedVirtualMachine.state, .stopped)
+        XCTAssertEqual(managedVirtualMachine.cleaned, true)
+    }
+
+    func testCallingStopAndCleanWithError() async throws {
+        try await slot.start(managedVirtualMachine: managedVirtualMachine)
+        try await slot.stop(withError: MockManagedVirtualMachine.Errors.genericError, clean: true)
+        XCTAssertEqual(slot.state, .crashed(MockManagedVirtualMachine.Errors.genericError))
+        XCTAssertEqual(managedVirtualMachine.state, .stopped)
+        XCTAssertEqual(managedVirtualMachine.cleaned, true)
+    }
+
+    func testAvailability() async throws {
+        XCTAssertEqual(slot.isAvailable, true)
+        try await slot.start(managedVirtualMachine: managedVirtualMachine)
+        XCTAssertEqual(slot.isAvailable, false)
+        try await slot.stop()
+        XCTAssertEqual(slot.isAvailable, true)
+    }
+
+    func testIsConfiguredForHandle() async throws {
+        XCTAssertFalse(slot.isConfiguredForHandle("test-handle"))
+        try await slot.start(managedVirtualMachine: managedVirtualMachine)
+        XCTAssertTrue(slot.isConfiguredForHandle("test-handle"))
+        XCTAssertFalse(slot.isConfiguredForHandle("test-handle-bad"))
+        try await slot.stop()
+        XCTAssertFalse(slot.isConfiguredForHandle("test-handle"))
+    }
+
+    func testDelegateSettings() async throws {
+        XCTAssertFalse(managedVirtualMachine.delegateSet)
+        try await slot.start(managedVirtualMachine: managedVirtualMachine)
+        XCTAssertTrue(managedVirtualMachine.delegateSet)
+    }
+
+    func testErrorThrownWhenStopCalledWhileStopping() async throws {
+        managedVirtualMachine.stopDelay = .seconds(5)
+        try await slot.start(managedVirtualMachine: managedVirtualMachine)
+        XCTAssertEqual(managedVirtualMachine.state, .started)
+
+        await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask { @MainActor in
+                try await self.slot.stop()
+            }
+
+            group.addTask { @MainActor in
+                // Give the slot a moment to switch to .stopping
+                try await Task.sleep(for: .seconds(1))
+                switch self.slot.state {
+                case .stopping: break
+                default: XCTFail("Expected to be in the starting state.")
+                }
+
+                do {
+                    try await self.slot.stop()
+                } catch VirtualMachineSlot.Errors.invalidStopState {
+                    // Expected
+                } catch {
+                    XCTFail(error.localizedDescription)
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
#135 [introduced a bug](https://github.com/Automattic/hostmgr/pull/135/files#diff-ea4122eff37a787d0639f5d4fb208d830966113e853b89f260ffb2e58341fb46R210) where the handle couldn't be retrieved because `stop` had already been called - effectively wiping the handle.

**This PR**
- Fixes that bug so stopped ephemeral VMs that fire the delegate methods are properly cleaned
- Handles cleaning VMs that are stopped via the Menu Bar

**Testing**
- Testing steps from #118 