### PR TITLE
Add parameter to control readonly when calling match

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,5 +16,8 @@ AllCops:
   TargetRubyVersion: 3.2.2
   SuggestExtensions: false
 
+Metrics/MethodLength:
+  Max: 16
+
 Style/HashSyntax:
   EnforcedShorthandSyntax: never

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -50,7 +50,7 @@ lane :upload_release do
 end
 
 desc 'Download the development signing certificates to this machine'
-lane :set_up_signing do
+lane :set_up_signing do |readonly: true|
   sync_code_signing(
     platform: 'macos',
     app_identifier: APPLE_BUNDLE_IDENTIFIER,
@@ -62,7 +62,7 @@ lane :set_up_signing do
     s3_region: 'us-east-2',
     s3_bucket: 'a8c-fastlane-match',
 
-    readonly: true
+    readonly: readonly
   )
 end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -19,12 +19,16 @@ GITHUB_REPO = 'automattic/hostmgr'
 APPLE_TEAM_ID = 'PZYM8XX95Q'
 APPLE_BUNDLE_IDENTIFIER = 'com.automattic.hostmgr'
 
-# Use this instead of getting values from ENV directly
-# It will throw an error if the requested value is missing
-def get_required_env(key)
-  UI.user_error!("Environment variable `#{key}` is not set.") unless ENV.key?(key)
-  ENV.fetch(key)
-end
+ASC_API_KEY_ENV_VARS = %w[
+  APP_STORE_CONNECT_API_KEY_KEY_ID
+  APP_STORE_CONNECT_API_KEY_ISSUER_ID
+  APP_STORE_CONNECT_API_KEY_KEY
+].freeze
+
+CODE_SIGNING_STORAGE_ENV_VARS = %w[
+  MATCH_S3_ACCESS_KEY
+  MATCH_S3_SECRET_ACCESS_KEY
+].freeze
 
 before_all do
   setup_ci # Fixes weird Keychain bugs
@@ -51,10 +55,13 @@ end
 
 desc 'Download the development signing certificates to this machine'
 lane :set_up_signing do |readonly: true|
+  require_env_vars!(*ASC_API_KEY_ENV_VARS, *CODE_SIGNING_STORAGE_ENV_VARS)
+
   sync_code_signing(
     platform: 'macos',
     app_identifier: APPLE_BUNDLE_IDENTIFIER,
     team_id: APPLE_TEAM_ID,
+    api_key: app_store_connect_api_key,
     type: 'development',
     certificate_id: 'Apple Development: Created via API (886NX39KP6)',
 
@@ -76,4 +83,18 @@ def create_release_zip
       end
     end
   end
+end
+
+# Use this to ensure all env vars a lane requires are set.
+#
+# The best place to call this is at the start of a lane, to fail early.
+def require_env_vars!(*keys)
+  keys.each { |key| get_required_env!(key) }
+end
+
+# Use this instead of getting values from `ENV` directly. It will throw an error if the requested value is missing.
+def get_required_env!(key)
+  return ENV.fetch(key) if ENV.key?(key)
+
+  UI.user_error!("Environment variable `#{key}` is not set.")
 end


### PR DESCRIPTION
Worked on this to enable creating a new dev profile, as prompted by our internal conversation at p1746921697025389-slack-C07DX5SGUVA

Notice that regenerating the dev profile is a quick workaround, we'll likely want to set aside some time to update the tooling to use a release profile to generate the binary at some point.

See also https://linear.app/a8c/issue/AINFRA-504