### PR TITLE
AINFRA-283 - Set `queue: mac` explicitly in pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,9 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 ---
 
+agents:
+  queue: mac
+
 env:
   IMAGE_ID: xcode-16.4
 
@@ -21,8 +24,6 @@ steps:
       install_swiftpm_dependencies
       swift test
     plugins: *common_plugins
-    agents:
-      queue: "mac"
 
   #################
   # Lint
@@ -47,8 +48,6 @@ steps:
       bundle exec fastlane set_up_signing
       make build verify-signing
     plugins: *common_plugins
-    agents:
-      queue: "mac"
 
   #################
   # Publish the Binary (if we're building a tag)
@@ -65,5 +64,3 @@ steps:
       - "test"
       - "validate-release-build"
     if: build.tag != null
-    agents:
-      queue: "mac"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,10 +1,13 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+---
+
+env:
+  IMAGE_ID: xcode-16.1-v4
+
 # Nodes with values to reuse in the pipeline.
 common_params:
   plugins: &common_plugins
     - automattic/a8c-ci-toolkit#3.7.1
-  # Common environment values to use with the `env` key.
-  env: &common_env
-    IMAGE_ID: xcode-16.1-v4
 
 # This is the default pipeline – it will build and test the app
 steps:
@@ -17,7 +20,6 @@ steps:
       echo "--- :swift: Building + Testing"
       install_swiftpm_dependencies
       swift test
-    env: *common_env
     plugins: *common_plugins
     agents:
       queue: "mac"
@@ -44,7 +46,6 @@ steps:
       install_gems
       bundle exec fastlane set_up_signing
       make build verify-signing
-    env: *common_env
     plugins: *common_plugins
     agents:
       queue: "mac"
@@ -59,7 +60,6 @@ steps:
       bundle exec fastlane set_up_signing
       make build
       bundle exec fastlane upload_release
-    env: *common_env
     plugins: *common_plugins
     depends_on:
       - "test"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,16 +1,13 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 ---
 
-agents:
-  queue: mac
-
 env:
   IMAGE_ID: xcode-16.4
 
 # Nodes with values to reuse in the pipeline.
 common_params:
   plugins: &common_plugins
-    - automattic/a8c-ci-toolkit#3.7.1
+    - automattic/a8c-ci-toolkit#5.3.1
 
 # This is the default pipeline – it will build and test the app
 steps:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,8 +1,11 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 ---
 
+agents:
+  queue: mac
+
 env:
-  IMAGE_ID: xcode-16.1-v4
+  IMAGE_ID: xcode-16.4
 
 # Nodes with values to reuse in the pipeline.
 common_params:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,7 +5,7 @@ agents:
   queue: mac
 
 env:
-  IMAGE_ID: xcode-16.4
+  IMAGE_ID: xcode-16.1-v4
 
 # Nodes with values to reuse in the pipeline.
 common_params:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,7 +5,7 @@ agents:
   queue: mac
 
 env:
-  IMAGE_ID: xcode-16.1-v4
+  IMAGE_ID: xcode-16.4
 
 # Nodes with values to reuse in the pipeline.
 common_params:

--- a/Tests/libhostmgrTests/TestHelpers.swift
+++ b/Tests/libhostmgrTests/TestHelpers.swift
@@ -18,14 +18,6 @@ extension S3Object {
     }
 }
 
-extension XCTest {
-    func XCTAssert(_ data: Data, hasHash hash: String, file: StaticString = #file, line: UInt = #line) {
-        var hasher = SHA256()
-        hasher.update(data: data)
-        XCTAssertEqual(Data(hasher.finalize()).base64EncodedString(), hash, file: file, line: line)
-    }
-}
-
 func getPathForEnvFile(named key: String) -> URL {
     Bundle.module.url(forResource: key, withExtension: "env")!
 }

--- a/Tests/libhostmgrTests/VM/VMConfigFileTests.swift
+++ b/Tests/libhostmgrTests/VM/VMConfigFileTests.swift
@@ -27,17 +27,36 @@ final class VMConfigFileTests: XCTestCase {
     }
 
     func testThatHardwareModelIsParsedCorrectly() throws {
-        XCTAssert(
-            try configFileSample1.hardwareModel.dataRepresentation,
-            hasHash: "3aTbdKrJ+27C8JaCzSmHNr32t5IbeuA5VjC48XCcGu8="
-        )
+        let dataRep = try configFileSample1.hardwareModel.dataRepresentation
+        // The `dataRepresentation` is supposed to be an opaque value / implementation detail,
+        // but that's the only property we have access to and we can thus use for testing correct parsing.
+        //
+        // This `dataRepresentation` happens to be a binary plist representation of a NSDictionary.
+        // We can't just compare the `dataRepresentation` directly with a fixed value though, because different
+        // versions of macOS might serialize the exact same NSDictionary as a slightly different NSData representation.
+        // Besides, future macOS versions might add additional keys in that internal representation of those objects.
+        //
+        // So the best we can do is check that the `dataRepresentation` is not nil and check some keys in that dict.
+        // This is a bit fragile but at least it's more resilient than comparing the `dataRepresentation` directly.
+        let dictRep = try XCTUnwrap(PropertyListSerialization.propertyList(from: dataRep, format: nil) as? NSDictionary)
+        XCTAssertEqual(dictRep["MinimumSupportedOS"] as? NSArray, [13, 0, 0])
+        XCTAssertEqual(dictRep["PlatformVersion"] as? NSNumber, 2)
     }
 
     func testThatMachineIdentifierIsParsedCorrectly() throws {
-        XCTAssert(
-            try configFileSample1.machineIdentifier.dataRepresentation,
-            hasHash: "0DXW7UIFta6W86ZZd24QUy4Gx3EX1+r9i+yYk7xHi0s="
-        )
+        let dataRep = try configFileSample1.machineIdentifier.dataRepresentation
+        // The `dataRepresentation` is supposed to be an opaque value / implementation detail,
+        // but that's the only property we have access to and we can thus use for testing correct parsing.
+        //
+        // This `dataRepresentation` happens to be a binary plist representation of a NSDictionary.
+        // We can't just compare the `dataRepresentation` directly with a fixed value though, because different
+        // versions of macOS might serialize the exact same NSDictionary as a slightly different NSData representation.
+        // Besides, future macOS versions might add additional keys in that internal representation of those objects.
+        //
+        // So the best we can do is check that the `dataRepresentation` is not nil and check some keys in that dict.
+        // This is a bit fragile but at least it's more resilient than comparing the `dataRepresentation` directly.
+        let dictRep = try XCTUnwrap(PropertyListSerialization.propertyList(from: dataRep, format: nil) as? NSDictionary)
+        XCTAssertNotNil(dictRep["ECID"])
     }
 
     func testThatMacAddressIsParsedCorrectly() throws {


### PR DESCRIPTION
This will allow adopting an improved default pipeline upload step on the CI infrastructure side of the setup. It also makes it clear what queue is in use just by looking at the pipeline file.

Notice it does not introduce the standard `shared-pipeline-vars` file because to use that we first need the default pipeline upload step in the IaC configuration.

See https://linear.app/a8c/issue/AINFRA-283