### PR TITLE
Update Xcode version to 16.4 & Fix Unit Tests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,7 +5,7 @@ agents:
   queue: mac
 
 env:
-  IMAGE_ID: xcode-16.1-v4
+  IMAGE_ID: xcode-16.4
 
 # Nodes with values to reuse in the pipeline.
 common_params:

--- a/Tests/libhostmgrTests/TestHelpers.swift
+++ b/Tests/libhostmgrTests/TestHelpers.swift
@@ -18,14 +18,6 @@ extension S3Object {
     }
 }
 
-extension XCTest {
-    func XCTAssert(_ data: Data, hasHash hash: String, file: StaticString = #file, line: UInt = #line) {
-        var hasher = SHA256()
-        hasher.update(data: data)
-        XCTAssertEqual(Data(hasher.finalize()).base64EncodedString(), hash, file: file, line: line)
-    }
-}
-
 func getPathForEnvFile(named key: String) -> URL {
     Bundle.module.url(forResource: key, withExtension: "env")!
 }

--- a/Tests/libhostmgrTests/VM/VMConfigFileTests.swift
+++ b/Tests/libhostmgrTests/VM/VMConfigFileTests.swift
@@ -27,17 +27,36 @@ final class VMConfigFileTests: XCTestCase {
     }
 
     func testThatHardwareModelIsParsedCorrectly() throws {
-        XCTAssert(
-            try configFileSample1.hardwareModel.dataRepresentation,
-            hasHash: "3aTbdKrJ+27C8JaCzSmHNr32t5IbeuA5VjC48XCcGu8="
-        )
+        let dataRep = try configFileSample1.hardwareModel.dataRepresentation
+        // The `dataRepresentation` is supposed to be an opaque value / implementation detail,
+        // but that's the only property we have access to and we can thus use for testing correct parsing.
+        //
+        // This `dataRepresentation` happens to be a binary plist representation of a NSDictionary.
+        // We can't just compare the `dataRepresentation` directly with a fixed value though, because different
+        // versions of macOS might serialize the exact same NSDictionary as a slightly different NSData representation.
+        // Besides, future macOS versions might add additional keys in that internal representation of those objects.
+        //
+        // So the best we can do is check that the `dataRepresentation` is not nil and check some keys in that dict.
+        // This is a bit fragile but at least it's more resilient than comparing the `dataRepresentation` directly.
+        let dictRep = try XCTUnwrap(PropertyListSerialization.propertyList(from: dataRep, format: nil) as? NSDictionary)
+        XCTAssertEqual(dictRep["MinimumSupportedOS"] as? NSArray, [13, 0, 0])
+        XCTAssertEqual(dictRep["PlatformVersion"] as? NSNumber, 2)
     }
 
     func testThatMachineIdentifierIsParsedCorrectly() throws {
-        XCTAssert(
-            try configFileSample1.machineIdentifier.dataRepresentation,
-            hasHash: "0DXW7UIFta6W86ZZd24QUy4Gx3EX1+r9i+yYk7xHi0s="
-        )
+        let dataRep = try configFileSample1.machineIdentifier.dataRepresentation
+        // The `dataRepresentation` is supposed to be an opaque value / implementation detail,
+        // but that's the only property we have access to and we can thus use for testing correct parsing.
+        //
+        // This `dataRepresentation` happens to be a binary plist representation of a NSDictionary.
+        // We can't just compare the `dataRepresentation` directly with a fixed value though, because different
+        // versions of macOS might serialize the exact same NSDictionary as a slightly different NSData representation.
+        // Besides, future macOS versions might add additional keys in that internal representation of those objects.
+        //
+        // So the best we can do is check that the `dataRepresentation` is not nil and check some keys in that dict.
+        // This is a bit fragile but at least it's more resilient than comparing the `dataRepresentation` directly.
+        let dictRep = try XCTUnwrap(PropertyListSerialization.propertyList(from: dataRep, format: nil) as? NSDictionary)
+        XCTAssertNotNil(dictRep["ECID"])
     }
 
     func testThatMacAddressIsParsedCorrectly() throws {


### PR DESCRIPTION
Closes AINFRA-782

This PR builds on top of https://github.com/Automattic/hostmgr/pull/147

It updates the CI to build on Xcode 16.4, which required to [fix Unit Tests around `VMConfigFileTest`](https://github.com/Automattic/hostmgr/pull/147#discussion_r2151173290) to pass.

## Fixing the failing tests

Two tests were failing because of how those relied on comparing the `dataRepresentation` of some `VZ…` objects (because that's the only property we have access to on those opaque objects); but that `dataRepresentation` (which happens to be a binary plist representation of an internal and opaque dictionary) and the encoding of that `bplist` changed between macOS 14.x (used by VM image `xcode-16.1-v4`) and macOS 15.x (used by VM image `xcode-16.4`)

<details><summary>Swift Playground showing how the <tt>dataRepresentation</tt> might not be idempotent</summary>

```swift
import Foundation
import Virtualization

let hardwareModelData = Data(base64Encoded: "YnBsaXN0MDDTAQIDBAUGXxAZRGF0YVJlcHJlc2VudGF0aW9uVmVyc2lvbl8QD1BsYXRmb3JtVmVyc2lvbl8QEk1pbmltdW1TdXBwb3J0ZWRPUxQAAAAAAAAAAAAAAAAAAAABEAKjBwgIEA0QAAgPKz1SY2VpawAAAAAAAAEBAAAAAAAAAAkAAAAAAAAAAAAAAAAAAABt")!
let dictBefore = try PropertyListSerialization.propertyList(from: hardwareModelData, format: nil) as? NSDictionary

let roundTripData = VZMacHardwareModel(dataRepresentation: hardwareModelData)!.dataRepresentation
/* YnBsaXN0MDDTAQIDBAUGXxAZRGF0YVJlcHJlc2VudGF0aW9uVmVyc2lvbl8QD1BsYXRmb3JtVmVyc2lvbl8QEk1pbmltdW1TdXBwb3J0ZWRPUxABEAKjBwgIEA0QAAgPKz1SVFZaXAAAAAAAAAEBAAAAAAAAAAkAAAAAAAAAAAAAAAAAAABe */

let dictAfter = try PropertyListSerialization.propertyList(from: roundTripData, format: nil) as? NSDictionary

roundTripData == hardwareModelData // false -- the inner bplist representations differ (see their base64 representation above too)
dictBefore == dictAfter            // true  -- the dictionary those 2 different bplist were representing are still the same though
```
</details>

---

### Alternatives Considered

We could also have just updated the expected values for the new `dataRepresentation` to the ones returned for those `VZ…` objects in macOS 15.x, in place the expected values we had for those back in macOS 14.x.

But based on [my understanding of the implementation detail of the Binary Plist format](https://medium.com/@karaiskc/understanding-apples-binary-property-list-format-281e6da00dbd), the fact that the `dataRepresentation` of those `VZ…` objects changed is not _strictly_ because e.g. macOS changed the bplist _format_ in 15.x, but more because the same object can be serialized in different equivalent ways as a bplist [^1].

So maybe in macOS 15.5 they changed the inner implementation of the serializer which led to different _choices_ for _which alternate representation_ to use to encode each object (or switched from `NSPropertyListSerializer` to  `PropertyListDecoder` or something?). But that also means that the `bplist` representation of a given dictionary is not guaranteed to be deterministic anyway. So we'd still not be guaranteed to always have the same binary plist `dataRepresentation` in each test run.

[^1]: Think e.g. order of keys in a dictionary being arbitrary + objects being encoded in a table with object references and offset pointers that can be serialized in an arbitrary order while still representing the same tree of objects + multiple ways to represent the same integer in the bplist depending on how many bytes you choose to use to serialize it…