### PR TITLE
Use Xcode 26.1.1

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,7 +5,7 @@ agents:
   queue: mac
 
 env:
-  IMAGE_ID: xcode-16.4
+  IMAGE_ID: xcode-26.1.1
 
 # Nodes with values to reuse in the pipeline.
 common_params:

--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,8 @@ gem 'aws-sdk-s3', '~> 1.119'
 gem 'fastlane', '~> 2.212'
 
 gem 'rubocop', '~> 1.64', require: false
+
+# only added to work around a Ruby 
+# failure that's present on the CI image
+# see: https://github.com/ruby/openssl/issues/949
+gem "openssl", "~> 4.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -173,6 +173,7 @@ GEM
     nanaimo (0.4.0)
     naturally (2.3.0)
     nkf (0.2.0)
+    openssl (4.0.0)
     optparse (0.8.0)
     os (1.1.4)
     parallel (1.26.3)
@@ -247,7 +248,8 @@ PLATFORMS
 DEPENDENCIES
   aws-sdk-s3 (~> 1.119)
   fastlane (~> 2.212)
+  openssl (~> 4.0)
   rubocop (~> 1.64)
 
 BUNDLED WITH
-   2.5.22
+   2.4.22


### PR DESCRIPTION
Updates the CI image to Xcode 26.1.1 and adds the appropriate Ruby + OpenSSL workaround.