### PR TITLE
Increase default disk size from 120GB to 160GB

### DIFF
--- a/Sources/hostmgr/commands/vm/VMCreate.swift
+++ b/Sources/hostmgr/commands/vm/VMCreate.swift
@@ -18,7 +18,7 @@ struct VMCreateCommand: AsyncParsableCommand {
     var quiet: Bool = false
 
     @Option(help: "The disk size of machine that should be created, in GB")
-    var diskSize: Int = 120
+    var diskSize: Int = 160
 
     private enum CodingKeys: String, CodingKey {
         case name


### PR DESCRIPTION
Closes [AINFRA-1921](https://linear.app/a8c/issue/AINFRA-1921/xcode-262-vm-no-space-left-on-device)

See https://github.com/Automattic/buildkite-ci/pull/808

# Why?

Our VMs have more and more things installed within them, and the free disk space is becoming a bit short, so 120GB was becoming to small—especially as we installed additional runtimes starting the `xcode-26.2` VM (internal ref: paaHJt-9AT-p2).

In fact we recently had to update the `xcode-26.2` VM (which was originally generated with a `diskSize` of `120`) to use 160GB instead (using [the `diskutil image resize` trick](https://github.com/Automattic/buildkite-ci/blob/trunk/src/agents/macos-vms/README.md#updating-a-vm-template-based-on-a-previous-one-patching-mistakes))

The change in this PR makes it so that from now on our future VMs will use 160GB by default too.