### PR TITLE
Suggest publish command when mirror missing

### DIFF
--- a/Sources/hostmgr/commands/cache/GitMirrorFetchCommand.swift
+++ b/Sources/hostmgr/commands/cache/GitMirrorFetchCommand.swift
@@ -32,7 +32,14 @@ struct GitMirrorFetchCommand: AsyncParsableCommand {
             Console.info("Fetching the Git Mirror for \(gitMirror.url)")
 
             guard let server = try await servers.first(havingFileNamed: gitMirror.remoteFilename) else {
-                Console.exit("No Git Mirror found for \(gitMirror.slug)", style: .error)
+                Console.exit(
+                    """
+                    No Git Mirror found for \(gitMirror.slug).
+                    To publish one, clone the repo locally and run:
+                      hostmgr cache publish-git-mirror --git-mirror \(gitMirror.url)
+                    """,
+                    style: .error
+                )
             }
 
             let progress = Console.startProgress("Downloading Git Mirror", type: .download)


### PR DESCRIPTION
## Summary

- When `fetch-git-mirror` can't find a mirror for a repo, the error message now includes the exact `publish-git-mirror` command to run
- Helps new repos self-serve instead of hitting a cryptic "not found" error

Additional context: Run into this working [on TumblrSync](https://buildkite.com/automattic/tumblrsync/builds/8/steps/canvas?sid=019c7920-e08a-4748-a6fb-0c6af57cb1d7&tab=output#019c7920-e0b3-41e5-ab5b-ad9d94804aed/L79):

<img width="1008" height="174" alt="image" src="https://github.com/user-attachments/assets/8809f9ee-364a-477a-bf9c-b6221a5627ce" />


## Test plan

- [x] Run `hostmgr cache fetch-git-mirror --git-mirror <url-without-mirror>` and verify the output includes the publish command suggestion

<img width="849" height="255" alt="image" src="https://github.com/user-attachments/assets/c3f4fce5-bf62-4eb5-b0fa-e5cc5422cbda" />

---

*Posted by Claude Code (Opus 4.6) on behalf of @mokagio with approval.*

🤖 Generated with [Claude Code](https://claude.ai/code)