### PR TITLE
Add `boostrap` make task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,19 +7,21 @@ RUBY_VERSION = $(shell cat .ruby-version)
 CERTIFICATE_NAME_DEBUG = Apple Development: Created via API (886NX39KP6)
 CERTIFICATE_NAME_RELEASE = Apple Distribution: Automattic, Inc. (PZYM8XX95Q)
 
+bootstrap: bootstrap-ruby lint build-debug
+
+bootstrap-ruby:
+	bundle install
+
 clean:
 	rm -rf .build
 
-fetch-codesignging:
-	bundle install
+fetch-codesignging: boostrap-ruby
 	bundle exec fastlane set_up_signing
 
-fetch-codesignging-debug:
-	bundle install
+fetch-codesignging-debug: boostrap-ruby
 	bundle exec fastlane set_up_signing_development
 
-fetch-codesignging-release:
-	bundle install
+fetch-codesignging-release: bootstrap-ruby
 	bundle exec fastlane set_up_signing_release
 
 build:

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ RUBY_VERSION = $(shell cat .ruby-version)
 CERTIFICATE_NAME_DEBUG = Apple Development: Created via API (886NX39KP6)
 CERTIFICATE_NAME_RELEASE = Apple Distribution: Automattic, Inc. (PZYM8XX95Q)
 
-bootstrap: bootstrap-ruby lint build-debug
+bootstrap: bootstrap-ruby lint test build-debug
 
 bootstrap-ruby:
 	bundle install

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,9 @@ bootstrap-ruby:
 clean:
 	rm -rf .build
 
+test:
+	swift test
+
 fetch-codesignging: boostrap-ruby
 	bundle exec fastlane set_up_signing
 


### PR DESCRIPTION
It might be useful for agents and human alike to have a single command to run after a clone.

This is also relevant in a worktree-based dev environment, where new work trees don't have access to the vendored gems from the repository root.