### PR TITLE
Fix git mirror corruption causing persistent build failures

### DIFF
--- a/Sources/hostmgr/commands/cache/GitMirrorFetchCommand.swift
+++ b/Sources/hostmgr/commands/cache/GitMirrorFetchCommand.swift
@@ -24,6 +24,10 @@ struct GitMirrorFetchCommand: AsyncParsableCommand {
         case gitMirror
     }
 
+    /// Minimum valid archive size in bytes. Archives smaller than this are almost certainly corrupted
+    /// or empty, since even a minimal git repo compresses to more than 1 KB.
+    static let minimumArchiveSize = 1024
+
     func run() async throws {
 
         let gitMirror = try self.gitMirror ?? GitMirror.fromEnvironment(key: "BUILDKITE_REPO")
@@ -42,12 +46,29 @@ struct GitMirrorFetchCommand: AsyncParsableCommand {
                 progress: progress.update
             )
 
+            // Validate the downloaded archive is not empty or corrupted
+            let archiveSize = try FileManager.default.size(ofObjectAt: gitMirror.archivePath)
+            if archiveSize < Self.minimumArchiveSize {
+                Console.warn("Downloaded archive is too small (\(archiveSize) bytes) – removing corrupted file")
+                try FileManager.default.removeItem(at: gitMirror.archivePath)
+                Console.exit("Downloaded Git Mirror archive appears corrupted", style: .error)
+            }
+
             Console.success("Download Complete")
         }
 
         if try !gitMirror.existsLocally {
             Console.info("Decompressing to \(Format.path(gitMirror.localPath))")
-            try gitMirror.decompress()
+            do {
+                try gitMirror.decompress()
+            } catch {
+                // Clean up the corrupted archive and partial decompression directory so that the
+                // next run will re-download from the server instead of retrying the same bad file.
+                Console.warn("Decompression failed – removing corrupted archive and partial output")
+                try? FileManager.default.removeItemIfExists(at: gitMirror.archivePath)
+                try? FileManager.default.removeItemIfExists(at: gitMirror.localPath)
+                throw error
+            }
         }
 
         Console.success("Git Mirror is ready")

--- a/Sources/hostmgr/commands/cache/GitMirrorFetchCommand.swift
+++ b/Sources/hostmgr/commands/cache/GitMirrorFetchCommand.swift
@@ -73,6 +73,7 @@ struct GitMirrorFetchCommand: AsyncParsableCommand {
             try? gitMirror.removeArchive()
             throw error
         }
+        try? gitMirror.removeArchive()
 
         Console.success("Git Mirror is ready")
     }

--- a/Sources/hostmgr/commands/cache/GitMirrorFetchCommand.swift
+++ b/Sources/hostmgr/commands/cache/GitMirrorFetchCommand.swift
@@ -49,11 +49,9 @@ struct GitMirrorFetchCommand: AsyncParsableCommand {
             // Validate the downloaded archive is not empty or corrupted
             let archiveSize = try FileManager.default.size(ofObjectAt: gitMirror.archivePath)
             if archiveSize < Self.minimumArchiveSize {
-                Console.warn("Downloaded archive is too small (\(archiveSize) bytes) – removing corrupted file")
-                try FileManager.default.removeItem(at: gitMirror.archivePath)
-                throw ValidationError(
-                    "Downloaded Git Mirror archive appears corrupted (\(archiveSize) bytes)"
-                )
+                Console.error("Downloaded archive is too small (\(archiveSize) bytes) – removing corrupted file")
+                try? FileManager.default.removeItemIfExists(at: gitMirror.archivePath)
+                throw ExitCode.failure
             }
 
             Console.success("Download Complete")

--- a/Sources/hostmgr/commands/cache/GitMirrorFetchCommand.swift
+++ b/Sources/hostmgr/commands/cache/GitMirrorFetchCommand.swift
@@ -51,7 +51,9 @@ struct GitMirrorFetchCommand: AsyncParsableCommand {
             if archiveSize < Self.minimumArchiveSize {
                 Console.warn("Downloaded archive is too small (\(archiveSize) bytes) – removing corrupted file")
                 try FileManager.default.removeItem(at: gitMirror.archivePath)
-                Console.exit("Downloaded Git Mirror archive appears corrupted", style: .error)
+                throw ValidationError(
+                    "Downloaded Git Mirror archive appears corrupted (\(archiveSize) bytes)"
+                )
             }
 
             Console.success("Download Complete")

--- a/Sources/hostmgr/commands/cache/GitMirrorFetchCommand.swift
+++ b/Sources/hostmgr/commands/cache/GitMirrorFetchCommand.swift
@@ -62,11 +62,11 @@ struct GitMirrorFetchCommand: AsyncParsableCommand {
             do {
                 try gitMirror.decompress()
             } catch {
-                // Clean up the corrupted archive and partial decompression directory so that the
-                // next run will re-download from the server instead of retrying the same bad file.
-                Console.warn("Decompression failed – removing corrupted archive and partial output")
+                // Clean up the corrupted archive so that the next run will re-download from the
+                // server instead of retrying the same bad file. The partial decompression output
+                // is cleaned up by the defer block in GitMirror.decompress().
+                Console.warn("Decompression failed – removing corrupted archive")
                 try? FileManager.default.removeItemIfExists(at: gitMirror.archivePath)
-                try? FileManager.default.removeItemIfExists(at: gitMirror.localPath)
                 throw error
             }
         }

--- a/Sources/hostmgr/commands/cache/GitMirrorFetchCommand.swift
+++ b/Sources/hostmgr/commands/cache/GitMirrorFetchCommand.swift
@@ -55,7 +55,7 @@ struct GitMirrorFetchCommand: AsyncParsableCommand {
             let archiveSize = try FileManager.default.size(ofObjectAt: gitMirror.archivePath)
             if archiveSize < Self.minimumArchiveSize {
                 Console.error("Downloaded archive is too small (\(archiveSize) bytes) – removing corrupted file")
-                try? FileManager.default.removeItemIfExists(at: gitMirror.archivePath)
+                try? gitMirror.removeArchive()
                 throw ExitCode.failure
             }
 

--- a/Sources/libhostmgr/Model/FileTransferProgress.swift
+++ b/Sources/libhostmgr/Model/FileTransferProgress.swift
@@ -14,11 +14,14 @@ public struct FileTransferProgress {
     }
 
     var fractionComplete: Percentage {
-        Decimal(Double(self.completed) / Double(self.total))
+        guard total > 0 else { return 0 }
+        return Decimal(Double(self.completed) / Double(self.total))
     }
 
     var dataRate: Double {
-        return Double(self.completed) / Date().timeIntervalSince(startDate)
+        let elapsed = Date().timeIntervalSince(startDate)
+        guard elapsed > 0 else { return 0 }
+        return Double(self.completed) / elapsed
     }
 
     var estimatedTimeRemaining: TimeInterval {

--- a/Sources/libhostmgr/Model/GitMirror.swift
+++ b/Sources/libhostmgr/Model/GitMirror.swift
@@ -38,6 +38,9 @@ public struct GitMirror {
 
     func calculateRemoteFilename(given date: Date) -> String {
         let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.timeZone = TimeZone(identifier: "UTC")
         formatter.dateFormat = "yyyy-MM"
 
         return slug + "-" + formatter.string(from: date) + ".aar"

--- a/Sources/libhostmgr/Model/GitMirror.swift
+++ b/Sources/libhostmgr/Model/GitMirror.swift
@@ -38,7 +38,7 @@ public struct GitMirror {
 
     func calculateRemoteFilename(given date: Date) -> String {
         let formatter = DateFormatter()
-        formatter.dateFormat = "YYYY-MM"
+        formatter.dateFormat = "yyyy-MM"
 
         return slug + "-" + formatter.string(from: date) + ".aar"
     }

--- a/Sources/libhostmgr/Model/GitMirror.swift
+++ b/Sources/libhostmgr/Model/GitMirror.swift
@@ -85,6 +85,7 @@ public struct GitMirror {
             to: tempDirectory
         )
 
+        try FileManager.default.createParentDirectoryIfNotExists(for: localPath)
         try FileManager.default.moveItem(at: tempDirectory, to: localPath)
     }
 

--- a/Sources/libhostmgr/Model/GitMirror.swift
+++ b/Sources/libhostmgr/Model/GitMirror.swift
@@ -73,10 +73,19 @@ public struct GitMirror {
     }
 
     public func decompress() throws {
+        let tempDirectory = Paths.tempDirectory
+            .appendingPathComponent("git-mirror-unpack-\(slug)-\(UUID().uuidString)")
+
+        defer {
+            try? FileManager.default.removeItemIfExists(at: tempDirectory)
+        }
+
         try Compressor.decompress(
             archiveAt: archivePath,
-            to: localPath
+            to: tempDirectory
         )
+
+        try FileManager.default.moveItem(at: tempDirectory, to: localPath)
     }
 
     public static func fromEnvironment(

--- a/Tests/libhostmgrTests/Model/FileTransferProgressTests.swift
+++ b/Tests/libhostmgrTests/Model/FileTransferProgressTests.swift
@@ -15,9 +15,10 @@ final class FileTransferProgressTests: XCTestCase {
     }
 
     func testDataRateWithZeroElapsedTime() {
-        let progress = FileTransferProgress(completed: 100, total: 200, startDate: Date())
-        XCTAssertFalse(progress.dataRate.isNaN)
-        XCTAssertFalse(progress.dataRate.isInfinite)
+        // startDate in the future so elapsed time is non-positive when dataRate is read,
+        // exercising the `guard elapsed > 0` branch deterministically.
+        let progress = FileTransferProgress(completed: 100, total: 200, startDate: Date(timeIntervalSinceNow: 60))
+        XCTAssertEqual(progress.dataRate, 0)
     }
 
     func testDataRateWithElapsedTime() {

--- a/Tests/libhostmgrTests/Model/FileTransferProgressTests.swift
+++ b/Tests/libhostmgrTests/Model/FileTransferProgressTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+@testable import libhostmgr
+
+final class FileTransferProgressTests: XCTestCase {
+
+    func testFractionCompleteWithZeroTotal() {
+        let progress = FileTransferProgress(completed: 0, total: 0, startDate: Date())
+        XCTAssertEqual(progress.fractionComplete, 0)
+        XCTAssertFalse(progress.fractionComplete.isNaN)
+    }
+
+    func testFractionCompleteWithNonZeroTotal() {
+        let progress = FileTransferProgress(completed: 50, total: 100, startDate: Date())
+        XCTAssertEqual(progress.fractionComplete, 0.5)
+    }
+
+    func testDataRateWithZeroElapsedTime() {
+        let progress = FileTransferProgress(completed: 100, total: 200, startDate: Date())
+        XCTAssertFalse(progress.dataRate.isNaN)
+        XCTAssertFalse(progress.dataRate.isInfinite)
+    }
+
+    func testDataRateWithElapsedTime() {
+        let progress = FileTransferProgress(completed: 1000, total: 2000, startDate: Date(timeIntervalSinceNow: -2))
+        XCTAssertEqual(progress.dataRate, 500, accuracy: 50)
+    }
+
+    func testEstimatedTimeRemainingWithZeroCompleted() {
+        let progress = FileTransferProgress(completed: 0, total: 100, startDate: Date())
+        XCTAssertFalse(progress.estimatedTimeRemaining.isNaN)
+    }
+
+    func testEstimatedTimeRemainingWithZeroTotal() {
+        let progress = FileTransferProgress(completed: 0, total: 0, startDate: Date())
+        XCTAssertFalse(progress.estimatedTimeRemaining.isNaN)
+    }
+}

--- a/Tests/libhostmgrTests/Model/GitMirrorTests.swift
+++ b/Tests/libhostmgrTests/Model/GitMirrorTests.swift
@@ -12,6 +12,15 @@ final class GitMirrorTests: XCTestCase {
         )
     }
 
+    func testThatRemoteFilenameUsesCalendarYearNearYearBoundary() throws {
+        // Dec 31, 2024 — ISO week-year (YYYY) would produce "2025", calendar year (yyyy) should produce "2024"
+        let dec31 = Date(timeIntervalSince1970: 1735603200)
+        XCTAssertEqual(
+            "git-github-com-Automattic-hostmgr-git-2024-12.aar",
+            subject.calculateRemoteFilename(given: dec31)
+        )
+    }
+
     func testThatErrorIsThrownForMissingEnvironmentVariable() throws {
         XCTAssertThrowsError(try GitMirror.fromEnvironment(key: "foo"))
     }

--- a/Tests/libhostmgrTests/Model/GitMirrorTests.swift
+++ b/Tests/libhostmgrTests/Model/GitMirrorTests.swift
@@ -21,6 +21,16 @@ final class GitMirrorTests: XCTestCase {
         )
     }
 
+    func testThatRemoteFilenameUsesUTCTimezone() throws {
+        // Jan 1, 2025 00:30 UTC — without explicit UTC, machines in western timezones
+        // (e.g. US/Pacific = UTC-8) would see this as Dec 31, 2024 and produce "2024-12"
+        let jan1UTC = Date(timeIntervalSince1970: 1735691400)
+        XCTAssertEqual(
+            "git-github-com-Automattic-hostmgr-git-2025-01.aar",
+            subject.calculateRemoteFilename(given: jan1UTC)
+        )
+    }
+
     func testThatErrorIsThrownForMissingEnvironmentVariable() throws {
         XCTAssertThrowsError(try GitMirror.fromEnvironment(key: "foo"))
     }


### PR DESCRIPTION
## Changes

- **Validate downloaded archives**: after downloading a `.aar` mirror, check file size is >= 1 KB. Empty/corrupted downloads are deleted immediately instead of persisting in `/opt/ci/var/tmp/`.
- **Clean up on decompression failure**: if `AppleArchive` decompression fails, remove both the corrupted `.aar` and the partial output directory so the next run re-downloads fresh instead of retrying the same bad file forever.
- **Fix NaN in progress display**: guard against division by zero in `FileTransferProgress` when the server returns no `Content-Length` (total = 0), which caused `NaN [Zero KB/s, About 504,686y 11mo remaining]` in logs.
- **Fix week-year date format**: change `YYYY` (ISO week-year) to `yyyy` (calendar year) in `DateFormatter` for archive filenames. Near year boundaries (e.g. Dec 31), `YYYY` can produce the wrong year, causing filename mismatches.

## Context

Pocket Casts Android release builds have been consistently [failing](https://buildkite.com/automattic/pocket-casts-android/builds/15925) since moving release builds from `mac-metal` to `mac` queue ([pocket-casts-android#5080](https://github.com/Automattic/pocket-casts-android/pull/5080)).
A first job works, but subsequent ones fail.

The root cause seems to be a corrupted `.aar` archive in the Synology cache that gets re-served on release builds build. Cleaning S3 and local mirrors didn't help because CloudSync re-syncs the corrupted file from Synology.

These changes prevent the corruption from persisting and make the system self-healing — a bad download will be detected and cleaned up automatically.

## Test plan

- [x] All 287 existing tests pass
- [x] New `FileTransferProgressTests` cover zero-total and zero-elapsed edge cases
- [x] New `GitMirrorTests.testThatRemoteFilenameUsesCalendarYearNearYearBoundary` verifies the `yyyy` fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)