### PR TITLE
Use closures to ensure that streams are closed in the correct order

### DIFF
--- a/Sources/libhostmgr/Compressor.swift
+++ b/Sources/libhostmgr/Compressor.swift
@@ -19,21 +19,22 @@ public struct Compressor {
 
         let destination = destination ?? FileManager.default.temporaryDirectory.appendingPathComponent("archive.aar")
 
-        guard
-            let archiveFilePath = FilePath(destination),
-            let writeFileStream = ArchiveByteStream.fileStream(
-                path: archiveFilePath,
-                mode: .writeOnly,
-                options: [ .create ],
-                permissions: FilePermissions(rawValue: 0o644)
-            ),
-            let compressionStream = ArchiveByteStream.compressionStream(using: .lzfse, writingTo: writeFileStream),
-            let encodeStream = ArchiveStream.encodeStream(writingTo: compressionStream)
-        else {
+        guard let archiveFilePath = FilePath(destination) else {
             throw Errors.unableToCompress
         }
 
-        try encodeStream.writeDirectoryContents(archiveFrom: FilePath(directory.path), keySet: keySet)
+        try ArchiveByteStream.withFileStream(
+            path: archiveFilePath,
+            mode: .writeOnly,
+            options: [ .create ],
+            permissions: FilePermissions(rawValue: 0o644)
+        ) { writeFileStream in
+            try ArchiveByteStream.withCompressionStream(using: .lzfse, writingTo: writeFileStream) { compStream in
+                try ArchiveStream.withEncodeStream(writingTo: compStream) { encodeStream in
+                    try encodeStream.writeDirectoryContents(archiveFrom: FilePath(directory.path), keySet: keySet)
+                }
+            }
+        }
 
         return destination
     }
@@ -49,24 +50,28 @@ public struct Compressor {
 
         guard
             let archiveFilePath = FilePath(archivePath),
-            let readFileStream = ArchiveByteStream.fileStream(
-                path: archiveFilePath,
-                mode: .readOnly,
-                options: [ ],
-                permissions: FilePermissions(rawValue: 0o644)
-            ),
-            let decompressionStream = ArchiveByteStream.decompressionStream(readingFrom: readFileStream),
-            let decodeStream = ArchiveStream.decodeStream(readingFrom: decompressionStream),
-            let decompressDestination = FilePath(destination),
-            let extractStream = ArchiveStream.extractStream(
-                extractingTo: decompressDestination,
-                flags: [ .ignoreOperationNotPermitted ]
-            )
+            let decompressDestination = FilePath(destination)
         else {
             throw Errors.unableToDecompress
         }
 
-        _ = try ArchiveStream.process(readingFrom: decodeStream, writingTo: extractStream)
+        try ArchiveByteStream.withFileStream(
+            path: archiveFilePath,
+            mode: .readOnly,
+            options: [ ],
+            permissions: FilePermissions(rawValue: 0o644)
+        ) { readFileStream in
+            try ArchiveByteStream.withDecompressionStream(readingFrom: readFileStream) { decompStream in
+                try ArchiveStream.withDecodeStream(readingFrom: decompStream) { decodeStream in
+                    try ArchiveStream.withExtractStream(
+                        extractingTo: decompressDestination,
+                        flags: [ .ignoreOperationNotPermitted ]
+                    ) { extractStream in
+                        _ = try ArchiveStream.process(readingFrom: decodeStream, writingTo: extractStream)
+                    }
+                }
+            }
+        }
 
         return destination
     }

--- a/Sources/libhostmgr/Compressor.swift
+++ b/Sources/libhostmgr/Compressor.swift
@@ -6,9 +6,8 @@ import AppleArchive
 public struct Compressor {
 
     enum Errors: Error {
-        case fileExistsAtPath
-        case unableToCompress
-        case unableToDecompress
+        case fileExists(at: String)
+        case invalidPath(String)
     }
 
     // From Apple Sample Code: https://developer.apple.com/documentation/accelerate/compressing_file_system_directories
@@ -20,7 +19,7 @@ public struct Compressor {
         let destination = destination ?? FileManager.default.temporaryDirectory.appendingPathComponent("archive.aar")
 
         guard let archiveFilePath = FilePath(destination) else {
-            throw Errors.unableToCompress
+            throw Errors.invalidPath(destination.path())
         }
 
         try ArchiveByteStream.withFileStream(
@@ -43,16 +42,17 @@ public struct Compressor {
     public static func decompress(archiveAt archivePath: URL, to destination: URL) throws -> URL {
 
         guard !FileManager.default.fileExists(at: destination) else {
-            throw Errors.fileExistsAtPath
+            throw Errors.fileExists(at: destination.path())
         }
 
         try FileManager.default.createDirectory(at: destination, withIntermediateDirectories: true)
 
-        guard
-            let archiveFilePath = FilePath(archivePath),
-            let decompressDestination = FilePath(destination)
-        else {
-            throw Errors.unableToDecompress
+        guard let archiveFilePath = FilePath(archivePath) else {
+            throw Errors.invalidPath(archivePath.path())
+        }
+
+        guard let decompressDestination = FilePath(destination) else {
+            throw Errors.invalidPath(destination.path())
         }
 
         try ArchiveByteStream.withFileStream(


### PR DESCRIPTION
AINFRA-2199

Root Cause: The compress() function in Compressor.swift was creating AppleArchive streams manually without explicitly closing them. The old code relied on Swift's ARC to close streams during deinitialization, but:

  1. ARC doesn't guarantee deallocation order - streams could close in wrong order (file before compression)
  2. Newer Swift/Xcode versions (26.2) have more aggressive optimizations that may defer or reorder deinitialization
  3. This left data in internal buffers, producing corrupted/incomplete .aar archives

  The Fix: Changed both compress() and decompress() to use Apple's recommended closure-based APIs:
  - ArchiveByteStream.withFileStream
  - ArchiveByteStream.withCompressionStream / withDecompressionStream
  - ArchiveStream.withEncodeStream / withDecodeStream / withExtractStream

These APIs guarantee streams are closed in the correct reverse order when the closure exits (either normally or via exception), properly flushing all buffered data.

Why it worked in 0.55.0: The older Xcode/Swift version likely had different optimization behavior that happened to deallocate streams in the right order. This was never correct - it was just lucky timing that newer versions of Xcode exposed.

**Testing:**

Using 0.56.0:
1. Pull down an image from S3 with `hostmgr vm fetch macos-15.6.1` (feel free to use one that already exists locally)
2. Make sure the `.aar` is extracted to a template, e.g. `/opt/ci/vm-images/macos-15.6.1.vmtemplate` (hostmgr is [supposed to remove the .aar after successful extraction](https://github.com/Automattic/hostmgr/pull/152))
3. Using 0.56.0 try to archive the VM via `hostmgr vm package macos-15.6.1`
4. Verify the archive via `aa list -i macos-15.6.1.vmtemplate.aar`
5. **Expectation:** An error will be shown.

Using this branch:
1. You should be able to reuse the VM path from step 2 above
2. Archive the VM via `hostmgr vm package macos-15.6.1`
3. Verify the archive via `aa list -i macos-15.6.1.vmtemplate.aar`
4. **Expectation:** No error is shown by the `aa` tool and the four files inside the archive are listed:

```
aa list -i macos-15.6.1.vmtemplate.aar

aux.img
config.json
image.img
manifest.json
```