### PR TITLE
Wipe git mirror archives after extraction

### DIFF
--- a/Sources/hostmgr/commands/cache/GitMirrorFetchCommand.swift
+++ b/Sources/hostmgr/commands/cache/GitMirrorFetchCommand.swift
@@ -28,6 +28,11 @@ struct GitMirrorFetchCommand: AsyncParsableCommand {
 
         let gitMirror = try self.gitMirror ?? GitMirror.fromEnvironment(key: "BUILDKITE_REPO")
 
+        guard try !gitMirror.existsLocally else {
+            Console.success("Git Mirror is ready")
+            return
+        }
+
         if try !gitMirror.archiveExistsLocally {
             Console.info("Fetching the Git Mirror for \(gitMirror.url)")
 
@@ -45,10 +50,9 @@ struct GitMirrorFetchCommand: AsyncParsableCommand {
             Console.success("Download Complete")
         }
 
-        if try !gitMirror.existsLocally {
-            Console.info("Decompressing to \(Format.path(gitMirror.localPath))")
-            try gitMirror.decompress()
-        }
+        Console.info("Decompressing to \(Format.path(gitMirror.localPath))")
+        try gitMirror.decompress()
+        try? gitMirror.removeArchive()
 
         Console.success("Git Mirror is ready")
     }

--- a/Sources/hostmgr/commands/cache/GitMirrorFetchCommand.swift
+++ b/Sources/hostmgr/commands/cache/GitMirrorFetchCommand.swift
@@ -29,7 +29,7 @@ struct GitMirrorFetchCommand: AsyncParsableCommand {
         let gitMirror = try self.gitMirror ?? GitMirror.fromEnvironment(key: "BUILDKITE_REPO")
 
         guard try !gitMirror.existsLocally else {
-            Console.success("Git Mirror is ready")
+            Console.success("Git Mirror already exists locally and is ready to use")
             return
         }
 

--- a/Sources/hostmgr/commands/cache/GitMirrorPublishCommand.swift
+++ b/Sources/hostmgr/commands/cache/GitMirrorPublishCommand.swift
@@ -46,6 +46,7 @@ struct GitMirrorPublishCommand: AsyncParsableCommand {
             .converted(to: .megabytes)
         if archiveSizeInMB.value < 50 {
             Console.info("Skipping uploading the git mirror because it is too small")
+            try? gitMirror.removeArchive()
             return
         }
 
@@ -60,6 +61,8 @@ struct GitMirrorPublishCommand: AsyncParsableCommand {
             allowResume: false,
             progress: progress.update
         )
+
+        try? gitMirror.removeArchive()
 
         Console.success("Upload complete")
     }

--- a/Sources/libhostmgr/Model/GitMirror.swift
+++ b/Sources/libhostmgr/Model/GitMirror.swift
@@ -76,6 +76,10 @@ public struct GitMirror {
         )
     }
 
+    public func removeArchive() throws {
+        try FileManager.default.removeItemIfExists(at: archivePath)
+    }
+
     public static func fromEnvironment(
         key: String,
         environment: [String: String] = ProcessInfo.processInfo.environment

--- a/Tests/libhostmgrTests/Model/GitMirrorTests.swift
+++ b/Tests/libhostmgrTests/Model/GitMirrorTests.swift
@@ -25,4 +25,22 @@ final class GitMirrorTests: XCTestCase {
         let environment = ["TEST_KEY": ""]
         XCTAssertThrowsError(try GitMirror.fromEnvironment(key: "TEST_KEY", environment: environment))
     }
+
+    func testRemoveArchiveDeletesFile() throws {
+        let archivePath = subject.archivePath
+        try FileManager.default.createDirectory(
+            at: archivePath.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        FileManager.default.createFile(atPath: archivePath.path, contents: Data("test".utf8))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: archivePath.path))
+
+        try subject.removeArchive()
+        XCTAssertFalse(FileManager.default.fileExists(atPath: archivePath.path))
+    }
+
+    func testRemoveArchiveSucceedsWhenFileDoesNotExist() throws {
+        XCTAssertFalse(FileManager.default.fileExists(atPath: subject.archivePath.path))
+        XCTAssertNoThrow(try subject.removeArchive())
+    }
 }


### PR DESCRIPTION
Resolves AINFRA-2323

## Summary
- The `publish-git-mirror` and `fetch-git-mirror` commands leave `.aar` archive files in `/opt/ci/var/tmp/` after they're done. Once uploaded to S3 or decompressed to the local mirror directory, the temp file is redundant.
  - **This is currently accounting for ~600 GB on each node at A8c**
- Adds `GitMirror.removeArchive()` and calls it after upload completes (publish) and after decompression completes (fetch). Uses `try?` so cleanup failure never fails the command itself.
- The `archiveExistsLocally` check in fetch previously skipped re-downloading, but this was unnecessary — the decompressed mirror at `localPath` is the real cache, and `existsLocally` already gates decompression.

## Test plan
- [x] Added `testRemoveArchiveDeletesFile` — creates a temp `.aar`, calls `removeArchive()`, verifies deletion
- [x] Added `testRemoveArchiveSucceedsWhenFileDoesNotExist` — verifies no error when file is absent
- [x] All existing `GitMirrorTests` still pass