### PR TITLE
Fixes shell injection in env-var escaping

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -78,8 +78,6 @@ let package = Package(
                 .copy("resources/buildkite-environment-variables-basic-expected-output.txt"),
                 .copy("resources/buildkite-environment-variables-basic.env"),
                 .copy("resources/buildkite-environment-variables-with-code-quotes.env"),
-                .copy("resources/buildkite-commit-message-original.txt"),
-                .copy("resources/buildkite-commit-message-expected.txt"),
                 .copy("resources/dhcpd_leases-1"),
                 .copy("resources/dhcpd_leases-2"),
                 .copy("resources/dotenv-fixtures.env"),

--- a/Sources/libhostmgr/BuildkiteScriptBuilder.swift
+++ b/Sources/libhostmgr/BuildkiteScriptBuilder.swift
@@ -88,16 +88,19 @@ public struct BuildkiteScriptBuilder {
 
     /// Helper that takes an environment variable key/value pair to an `export` statement.
     ///
-    /// Automatically quote-wraps the value and escapes quotes as needed.
+    /// Wraps the value using shell single-quote escaping. Single quotes disable all
+    /// shell expansion (no command substitution, no variable expansion, no backslash
+    /// processing), which is the only safe way to pass arbitrary attacker-controlled
+    /// data such as `BUILDKITE_MESSAGE` through to the remote shell.
     ///
     /// Example:
     ///
     /// ```
     /// # Given `foo:bar`
-    /// export foo="bar"
+    /// export foo='bar'
     /// ```
     func convertEnvironmentVariableToExport(_ pair: (String, Value)) -> String {
-        return "export \(pair.0)=\"\(pair.1.escapedRepresentation)\"".trimmingWhitespace
+        return "export \(pair.0)=\(pair.1.shellQuoted)".trimmingWhitespace
     }
 
     /// Helper that wraps command escape logic for shorthand use in a `map` statement.
@@ -115,11 +118,16 @@ public struct BuildkiteScriptBuilder {
             self.rawValue = wrapping
         }
 
-        /// An version of this value suitable for placement in a shell script
-        var escapedRepresentation: String {
-            rawValue
-                .escapingCodeQuotes
-                .escapingDoubleQuotes
+        /// The value formatted for safe placement in a shell script as a quoted token.
+        ///
+        /// Delegates to `spm_shellEscaped()`, which uses single-quote wrapping (with
+        /// `'\''` escaping for embedded single quotes). Single-quoted strings perform
+        /// no expansion in POSIX shells, so the resulting token is safe even when the
+        /// value contains backticks, dollar signs, backslashes, or other shell
+        /// metacharacters. Values that contain only allowlisted characters are
+        /// returned unquoted.
+        var shellQuoted: String {
+            rawValue.spm_shellEscaped()
         }
     }
 
@@ -151,13 +159,5 @@ public struct BuildkiteScriptBuilder {
 extension String {
     var escapingSpaces: String {
         replacingOccurrences(of: " ", with: "\\ ")
-    }
-
-    var escapingCodeQuotes: String {
-        replacingOccurrences(of: "`", with: "\\`")
-    }
-
-    var escapingDoubleQuotes: String {
-        replacingOccurrences(of: "\"", with: "\\\"")
     }
 }

--- a/Sources/libhostmgr/BuildkiteScriptBuilder.swift
+++ b/Sources/libhostmgr/BuildkiteScriptBuilder.swift
@@ -88,16 +88,23 @@ public struct BuildkiteScriptBuilder {
 
     /// Helper that takes an environment variable key/value pair to an `export` statement.
     ///
-    /// Wraps the value using shell single-quote escaping. Single quotes disable all
-    /// shell expansion (no command substitution, no variable expansion, no backslash
-    /// processing), which is the only safe way to pass arbitrary attacker-controlled
-    /// data such as `BUILDKITE_MESSAGE` through to the remote shell.
+    /// Renders the value via `Value.shellQuoted`, which delegates to
+    /// `spm_shellEscaped()`. Values containing only allowlisted characters
+    /// (alphanumerics plus `-_/:@%+=.,`) are emitted unquoted; anything else
+    /// is wrapped in single quotes on Unix (with `'\''` for embedded single
+    /// quotes) or double quotes on Windows. Either form disables shell
+    /// expansion of the value, which is the property we rely on to safely
+    /// pass attacker-controlled data such as `BUILDKITE_MESSAGE` through to
+    /// the remote shell.
     ///
-    /// Example:
+    /// Examples:
     ///
     /// ```
-    /// # Given `foo:bar`
-    /// export foo='bar'
+    /// # Given foo=bar       (allowlist-clean — emitted unquoted)
+    /// export foo=bar
+    ///
+    /// # Given foo=hello world
+    /// export foo='hello world'
     /// ```
     func convertEnvironmentVariableToExport(_ pair: (String, Value)) -> String {
         return "export \(pair.0)=\(pair.1.shellQuoted)".trimmingWhitespace

--- a/Tests/libhostmgrTests/BuildkiteScriptBuilderTests.swift
+++ b/Tests/libhostmgrTests/BuildkiteScriptBuilderTests.swift
@@ -44,7 +44,7 @@ class BuildkiteScriptBuilderTests: XCTestCase {
         )
         XCTAssertEqual(
             "automattic",
-            scriptBuilder.environmentVariables["BUILDKITE_ORGANIZATION_SLUG"]?.escapedRepresentation
+            scriptBuilder.environmentVariables["BUILDKITE_ORGANIZATION_SLUG"]?.shellQuoted
         )
     }
 
@@ -56,8 +56,8 @@ class BuildkiteScriptBuilderTests: XCTestCase {
             scriptBuilder.environmentVariables["BUILDKITE_MESSAGE"]
         )
         XCTAssertEqual(
-            "A simple message with \\`code quotes\\`",
-            scriptBuilder.environmentVariables["BUILDKITE_MESSAGE"]?.escapedRepresentation
+            "'A simple message with `code quotes`'",
+            scriptBuilder.environmentVariables["BUILDKITE_MESSAGE"]?.shellQuoted
         )
     }
 
@@ -70,16 +70,53 @@ class BuildkiteScriptBuilderTests: XCTestCase {
         )
     }
 
-    func testThatCommitMessageWithCodeQuotesIsProperlyEscaped() throws {
-        let original = try getContentsOfResourceAsValue(
-            named: "buildkite-commit-message-original",
-            withExtension: "txt"
-        )
+    // MARK: - Shell-injection regression tests
+    //
+    // BUILDKITE_MESSAGE is attacker-controllable — its value is the head commit's
+    // message, which any pull request author can set. The previous escaping
+    // (escapingCodeQuotes + escapingDoubleQuotes inside double quotes) was unsafe
+    // for messages containing a backslash followed by a backtick, because the
+    // existing backslash got consumed by the new escape, leaving the backtick
+    // active inside the double-quoted export and triggering command substitution
+    // when the script ran.
+    //
+    // These tests assert that no shell expansion happens for the value, by
+    // sourcing the generated export line in a real shell and reading the
+    // variable back.
 
-        XCTAssertEqual(
-            try getContentsOfResource(named: "buildkite-commit-message-expected", withExtension: "txt"),
-            original.escapedRepresentation
-        )
+    func testThatExportRoundTripsValueContainingBackslashBacktick() throws {
+        // The exact payload that triggered the original bug: backslash-backtick
+        // pairs around tokens. With the unsafe escaping, sourcing this export
+        // line in zsh or bash printed `command not found` and clobbered the
+        // value with the substituted output.
+        let payload = #"line with \`whoami\` and \`/etc/passwd\`"#
+        try assertExportPreservesValue(payload)
+    }
+
+    func testThatExportRoundTripsValueContainingPlainBackticks() throws {
+        try assertExportPreservesValue("plain `whoami` and `/etc/passwd`")
+    }
+
+    func testThatExportRoundTripsValueContainingDollarExpansion() throws {
+        try assertExportPreservesValue(#"value $HOME and ${PATH} should not expand"#)
+    }
+
+    func testThatExportRoundTripsValueContainingSingleQuotes() throws {
+        try assertExportPreservesValue("can't won't shouldn't")
+    }
+
+    func testThatExportRoundTripsValueContainingDoubleQuotes() throws {
+        try assertExportPreservesValue(#"a "quoted" word"#)
+    }
+
+    func testThatExportRoundTripsMultiLineCommitMessage() throws {
+        let payload = """
+        Subject line
+
+        Body with \\`escaped\\` and `plain` backticks,
+        plus a $variable and "quotes".
+        """
+        try assertExportPreservesValue(payload)
     }
 
     // MARK: - Command Tests
@@ -142,13 +179,6 @@ class BuildkiteScriptBuilderTests: XCTestCase {
     }
 
     // MARK: - Test Helpers
-    private func getContentsOfResourceAsValue(
-        named key: String,
-        withExtension extension: String
-    ) throws -> BuildkiteScriptBuilder.Value {
-        try BuildkiteScriptBuilder.Value(wrapping: getContentsOfResource(named: key, withExtension: `extension`))
-    }
-
     private func getContentsOfResource(named key: String, withExtension extension: String) throws -> String {
         let path = try XCTUnwrap(Bundle.module.path(forResource: key, ofType: `extension`))
         return try XCTUnwrap(String(contentsOfFile: path))
@@ -158,6 +188,73 @@ class BuildkiteScriptBuilderTests: XCTestCase {
         try DotEnv.read(path: path.path())
             .lines
             .reduce(into: [String: String]()) { $0[$1.key] = $1.value }
+    }
+
+    /// Asserts that the given value, when written into the script as an export
+    /// line and sourced by a real POSIX shell, round-trips byte-for-byte — i.e.
+    /// the shell performs no expansion, no command substitution, no backslash
+    /// processing on it.
+    ///
+    /// The check runs the generated export line through `/bin/sh -c`, reads the
+    /// variable back, and compares against the input. If shell expansion fires,
+    /// the read-back value will differ (or the shell will print errors and the
+    /// process may even fail).
+    private func assertExportPreservesValue(
+        _ value: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws {
+        var builder = BuildkiteScriptBuilder()
+        builder.addEnvironmentVariable(named: "BUILDKITE_TEST_VALUE", value: value)
+        let exportLine = builder.build()
+
+        // Source the generated script and emit the variable verbatim, framed by
+        // sentinels so we can extract it cleanly even if it contains newlines.
+        let shellScript = """
+        \(exportLine)
+        printf '<<<%s>>>' "$BUILDKITE_TEST_VALUE"
+        """
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = ["-c", shellScript]
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.standardOutput = stdout
+        process.standardError = stderr
+        try process.run()
+        process.waitUntilExit()
+
+        let stdoutData = stdout.fileHandleForReading.readDataToEndOfFile()
+        let stderrData = stderr.fileHandleForReading.readDataToEndOfFile()
+        let stdoutText = String(data: stdoutData, encoding: .utf8) ?? ""
+        let stderrText = String(data: stderrData, encoding: .utf8) ?? ""
+
+        XCTAssertEqual(
+            process.terminationStatus, 0,
+            "shell exited non-zero. stderr: \(stderrText)",
+            file: file, line: line
+        )
+        XCTAssertTrue(
+            stderrText.isEmpty,
+            "shell wrote to stderr (suggests expansion fired): \(stderrText)",
+            file: file, line: line
+        )
+
+        guard let start = stdoutText.range(of: "<<<"),
+              let end = stdoutText.range(of: ">>>", options: .backwards) else {
+            XCTFail(
+                "could not extract sentinel-framed value from stdout: \(stdoutText)",
+                file: file, line: line
+            )
+            return
+        }
+        let observed = String(stdoutText[start.upperBound..<end.lowerBound])
+        XCTAssertEqual(
+            observed, value,
+            "value did not round-trip through the shell",
+            file: file, line: line
+        )
     }
 }
 

--- a/Tests/libhostmgrTests/resources/buildkite-commit-message-expected.txt
+++ b/Tests/libhostmgrTests/resources/buildkite-commit-message-expected.txt
@@ -1,6 +1,0 @@
-…ViewController\`
-
-Notice I also updated the comment. I started with removing the
-\`AlertView\` reference, because that's an implementation detail that
-should be irrelevant for translators. Replacing it with \"alert view\"
-seemed too generic, so I added more explanation.

--- a/Tests/libhostmgrTests/resources/buildkite-commit-message-original.txt
+++ b/Tests/libhostmgrTests/resources/buildkite-commit-message-original.txt
@@ -1,6 +1,0 @@
-…ViewController`
-
-Notice I also updated the comment. I started with removing the
-`AlertView` reference, because that's an implementation detail that
-should be irrelevant for translators. Replacing it with "alert view"
-seemed too generic, so I added more explanation.

--- a/Tests/libhostmgrTests/resources/buildkite-environment-variables-basic-expected-output.txt
+++ b/Tests/libhostmgrTests/resources/buildkite-environment-variables-basic-expected-output.txt
@@ -1,19 +1,19 @@
 source ~/.circ
-export BUILDKITE="true"
-export BUILDKITE_AGENT_META_DATA_QUEUE="mac"
-export BUILDKITE_AGENT_NAME="builder"
-export BUILDKITE_BRANCH="trunk"
-export BUILDKITE_BUILD_ID="01825f54-2973-4ab9-96b1-8cf9eb06a4f6"
-export BUILDKITE_BUILD_NUMBER="9364"
-export BUILDKITE_BUILD_PATH="/usr/local/var/buildkite-agent/builds"
-export BUILDKITE_BUILD_URL="https://buildkite.com/automattic/wordpress-ios/builds/9364"
-export BUILDKITE_COMMAND=".buildkite/commands/build-for-testing.sh"
-export BUILDKITE_COMMIT="6fb314584170dd2817936c4835b178f8a4e55904"
-export BUILDKITE_LABEL="🛠 Build for Testing"
-export BUILDKITE_MESSAGE="Merge pull request #19134 from wordpress-mobile/task/add-lottie-sp"
-export BUILDKITE_ORGANIZATION_SLUG="automattic"
-export BUILDKITE_PIPELINE_SLUG="wordpress-ios"
-export BUILDKITE_PLUGINS="[{\\"github.com/automattic/bash-cache-buildkite-plugin#2.6.0\\":null},{\\"github.com/automattic/git-s3-cache-buildkite-plugin#v1.1.3\\":{\\"repo\\":\\"wordpress-mobile/wordpress-ios/\\",\\"bucket\\":\\"a8c-repo-mirrors\\"}}]"
-export BUILDKITE_REPO="git@github.com:wordpress-mobile/WordPress-iOS.git"
-export CI="true"
+export BUILDKITE=true
+export BUILDKITE_AGENT_META_DATA_QUEUE=mac
+export BUILDKITE_AGENT_NAME=builder
+export BUILDKITE_BRANCH=trunk
+export BUILDKITE_BUILD_ID=01825f54-2973-4ab9-96b1-8cf9eb06a4f6
+export BUILDKITE_BUILD_NUMBER=9364
+export BUILDKITE_BUILD_PATH=/usr/local/var/buildkite-agent/builds
+export BUILDKITE_BUILD_URL=https://buildkite.com/automattic/wordpress-ios/builds/9364
+export BUILDKITE_COMMAND=.buildkite/commands/build-for-testing.sh
+export BUILDKITE_COMMIT=6fb314584170dd2817936c4835b178f8a4e55904
+export BUILDKITE_LABEL='🛠 Build for Testing'
+export BUILDKITE_MESSAGE='Merge pull request #19134 from wordpress-mobile/task/add-lottie-sp'
+export BUILDKITE_ORGANIZATION_SLUG=automattic
+export BUILDKITE_PIPELINE_SLUG=wordpress-ios
+export BUILDKITE_PLUGINS='[{\"github.com/automattic/bash-cache-buildkite-plugin#2.6.0\":null},{\"github.com/automattic/git-s3-cache-buildkite-plugin#v1.1.3\":{\"repo\":\"wordpress-mobile/wordpress-ios/\",\"bucket\":\"a8c-repo-mirrors\"}}]'
+export BUILDKITE_REPO=git@github.com:wordpress-mobile/WordPress-iOS.git
+export CI=true
 buildkite-agent bootstrap


### PR DESCRIPTION
AINFRA-2345

The previous escaping (replace ` with \`, replace " with \", wrap in double quotes) was unsafe for values containing a literal backslash followed by a backtick. The existing backslash got consumed by the new escape, leaving the backtick active inside the double-quoted export and triggering command substitution when the script ran.

BUILDKITE_MESSAGE is attacker-controllable - its value is the head commit's message, which any pull request author can set. A commit message containing \`token\` (the form GitHub stores when a PR description uses markdown-escaped backticks) was sufficient to run arbitrary code as user `builder` on the macOS VM.

Switch to spm_shellEscaped(), which uses single-quote wrapping with '\'' escaping for embedded single quotes. Single-quoted strings perform no expansion in POSIX shells, so the value is safe even when it contains backticks, dollar signs, backslashes, or other shell metacharacters.

Add regression tests that source the generated export line in /bin/sh and assert the value round-trips byte-for-byte.