### PR TITLE
Fix generated Buildkite PATH expansion

### DIFF
--- a/Sources/hostmgr/commands/generate/GenerateBuildkiteJobScript.swift
+++ b/Sources/hostmgr/commands/generate/GenerateBuildkiteJobScript.swift
@@ -39,9 +39,10 @@ struct GenerateBuildkiteJobScript: ParsableCommand {
         scriptBuilder.addEnvironmentVariable(named: "BUILDKITE", value: "true")
         scriptBuilder.copyEnvironmentVariables(prefixedBy: "BUILDKITE_")
 
-        scriptBuilder.addEnvironmentVariable(
+        scriptBuilder.addPathEnvironmentVariable(
             named: "PATH",
-            value: "/opt/homebrew/bin:/opt/ci/bin:$PATH"
+            prepending: ["/opt/homebrew/bin", "/opt/ci/bin"],
+            existingVariableName: "PATH"
         )
 
         scriptBuilder.addCommand("buildkite-agent bootstrap")

--- a/Sources/libhostmgr/BuildkiteScriptBuilder.swift
+++ b/Sources/libhostmgr/BuildkiteScriptBuilder.swift
@@ -24,6 +24,7 @@ public struct BuildkiteScriptBuilder {
     ///
     /// If there's an existing environment variable with the same name, it will be overwritten.
     public mutating func addEnvironmentVariable(named key: String, value: String) {
+        precondition(Self.isValidEnvironmentVariableName(key), "Invalid environment variable name: \(key)")
         self.environmentVariables[key] = Value(wrapping: value)
     }
 
@@ -43,10 +44,10 @@ public struct BuildkiteScriptBuilder {
             Self.isValidEnvironmentVariableName(existingVariableName),
             "Invalid existing environment variable name: \(existingVariableName)"
         )
-        precondition(!paths.isEmpty, "PATH must have at least one component")
+        precondition(!paths.isEmpty, "\(key) must have at least one path component")
         precondition(
             paths.allSatisfy { !$0.isEmpty && !$0.contains(":") },
-            "PATH components must be non-empty and cannot contain ':'"
+            "\(key) path components must be non-empty and cannot contain ':'"
         )
         self.environmentVariables[key] = Value(pathPrepending: paths, existingVariableName: existingVariableName)
     }
@@ -62,12 +63,14 @@ public struct BuildkiteScriptBuilder {
     }
 
     /// Copy environment variables from the existing environment into the build script based on their prefix.
+    ///
+    /// Variables with names that cannot be represented safely in POSIX shell `export` syntax are ignored.
     public mutating func copyEnvironmentVariables(
         prefixedBy prefix: String,
         from environment: [String: String] = ProcessInfo.processInfo.environment
     ) {
-        for (key, value) in environment where key.starts(with: prefix) {
-            environmentVariables[key] = Value(wrapping: value)
+        for (key, value) in environment where key.starts(with: prefix) && Self.isValidEnvironmentVariableName(key) {
+            addEnvironmentVariable(named: key, value: value)
         }
     }
 
@@ -135,6 +138,7 @@ public struct BuildkiteScriptBuilder {
     /// export foo='hello world'
     /// ```
     func convertEnvironmentVariableToExport(_ pair: (String, Value)) -> String {
+        precondition(Self.isValidEnvironmentVariableName(pair.0), "Invalid environment variable name: \(pair.0)")
         return "export \(pair.0)=\(pair.1.shellRepresentation)".trimmingWhitespace
     }
 

--- a/Sources/libhostmgr/BuildkiteScriptBuilder.swift
+++ b/Sources/libhostmgr/BuildkiteScriptBuilder.swift
@@ -27,6 +27,30 @@ public struct BuildkiteScriptBuilder {
         self.environmentVariables[key] = Value(wrapping: value)
     }
 
+    /// Add a PATH-like environment variable that prepends paths to an existing shell variable.
+    ///
+    /// This is intentionally narrower than accepting a raw shell expression: each
+    /// path is shell-escaped, and only the final existing variable reference is
+    /// emitted as shell syntax. Path components must be non-empty and cannot
+    /// contain `:`, because PATH-like shell variables use `:` as their separator.
+    public mutating func addPathEnvironmentVariable(
+        named key: String,
+        prepending paths: [String],
+        existingVariableName: String
+    ) {
+        precondition(Self.isValidEnvironmentVariableName(key), "Invalid environment variable name: \(key)")
+        precondition(
+            Self.isValidEnvironmentVariableName(existingVariableName),
+            "Invalid existing environment variable name: \(existingVariableName)"
+        )
+        precondition(!paths.isEmpty, "PATH must have at least one component")
+        precondition(
+            paths.allSatisfy { !$0.isEmpty && !$0.contains(":") },
+            "PATH components must be non-empty and cannot contain ':'"
+        )
+        self.environmentVariables[key] = Value(pathPrepending: paths, existingVariableName: existingVariableName)
+    }
+
     /// Removes an environment variable pair from the build script.
     public mutating func removeEnvironmentVariable(named key: String) {
         self.environmentVariables.removeValue(forKey: key)
@@ -88,7 +112,7 @@ public struct BuildkiteScriptBuilder {
 
     /// Helper that takes an environment variable key/value pair to an `export` statement.
     ///
-    /// Renders the value via `Value.shellQuoted`, which delegates to
+    /// Renders literal values via `Value.shellQuoted`, which delegates to
     /// `spm_shellEscaped()`. Values containing only allowlisted characters
     /// (alphanumerics plus `-_/:@%+=.,`) are emitted unquoted; anything else
     /// is wrapped in single quotes on Unix (with `'\''` for embedded single
@@ -96,6 +120,10 @@ public struct BuildkiteScriptBuilder {
     /// expansion of the value, which is the property we rely on to safely
     /// pass attacker-controlled data such as `BUILDKITE_MESSAGE` through to
     /// the remote shell.
+    ///
+    /// PATH-like values are emitted by shell-escaping each path component and
+    /// conditionally appending a validated existing variable reference such as
+    /// `${PATH:+:$PATH}`.
     ///
     /// Examples:
     ///
@@ -107,7 +135,7 @@ public struct BuildkiteScriptBuilder {
     /// export foo='hello world'
     /// ```
     func convertEnvironmentVariableToExport(_ pair: (String, Value)) -> String {
-        return "export \(pair.0)=\(pair.1.shellQuoted)".trimmingWhitespace
+        return "export \(pair.0)=\(pair.1.shellRepresentation)".trimmingWhitespace
     }
 
     /// Helper that wraps command escape logic for shorthand use in a `map` statement.
@@ -119,10 +147,23 @@ public struct BuildkiteScriptBuilder {
     ///
     /// Mostly just a way to organize escaping
     struct Value: Equatable {
-        let rawValue: String
+        private let representation: ValueRepresentation
+
+        var rawValue: String {
+            switch representation {
+            case .literal(let value):
+                value
+            case .pathPrepending(let paths, let existingVariableName):
+                paths.joined(separator: ":") + "${\(existingVariableName):+:$\(existingVariableName)}"
+            }
+        }
 
         init(wrapping: String) {
-            self.rawValue = wrapping
+            self.representation = .literal(wrapping)
+        }
+
+        init(pathPrepending paths: [String], existingVariableName: String) {
+            self.representation = .pathPrepending(paths, existingVariableName: existingVariableName)
         }
 
         /// The value formatted for safe placement in a shell script as a quoted token.
@@ -136,6 +177,22 @@ public struct BuildkiteScriptBuilder {
         var shellQuoted: String {
             rawValue.spm_shellEscaped()
         }
+
+        /// The value formatted for placement after `KEY=` in an export statement.
+        var shellRepresentation: String {
+            switch representation {
+            case .literal:
+                shellQuoted
+            case .pathPrepending(let paths, let existingVariableName):
+                paths.map { $0.spm_shellEscaped() }.joined(separator: ":")
+                    + "${\(existingVariableName):+:$\(existingVariableName)}"
+            }
+        }
+    }
+
+    private enum ValueRepresentation: Equatable {
+        case literal(String)
+        case pathPrepending([String], existingVariableName: String)
     }
 
     /// An object representing one command in a shell script
@@ -166,5 +223,27 @@ public struct BuildkiteScriptBuilder {
 extension String {
     var escapingSpaces: String {
         replacingOccurrences(of: " ", with: "\\ ")
+    }
+}
+
+private extension BuildkiteScriptBuilder {
+    static func isValidEnvironmentVariableName(_ name: String) -> Bool {
+        guard let first = name.utf8.first else {
+            return false
+        }
+
+        let validFirstCharacter = first == UInt8(ascii: "_")
+            || (UInt8(ascii: "a")...UInt8(ascii: "z")).contains(first)
+            || (UInt8(ascii: "A")...UInt8(ascii: "Z")).contains(first)
+        guard validFirstCharacter else {
+            return false
+        }
+
+        return name.utf8.dropFirst().allSatisfy {
+            $0 == UInt8(ascii: "_")
+                || (UInt8(ascii: "a")...UInt8(ascii: "z")).contains($0)
+                || (UInt8(ascii: "A")...UInt8(ascii: "Z")).contains($0)
+                || (UInt8(ascii: "0")...UInt8(ascii: "9")).contains($0)
+        }
     }
 }

--- a/Tests/libhostmgrTests/BuildkiteScriptBuilderTests.swift
+++ b/Tests/libhostmgrTests/BuildkiteScriptBuilderTests.swift
@@ -70,6 +70,24 @@ class BuildkiteScriptBuilderTests: XCTestCase {
         )
     }
 
+    func testThatInvalidCopiedEnvironmentVariableNamesAreIgnored() throws {
+        let invalidName = "BUILDKITE_BAD; printf injected >&2 #"
+
+        scriptBuilder.copyEnvironmentVariables(
+            prefixedBy: "BUILDKITE_",
+            from: [
+                "BUILDKITE_SAFE": "safe",
+                invalidName: "unsafe"
+            ]
+        )
+
+        let script = scriptBuilder.build()
+        XCTAssertTrue(script.components(separatedBy: "\n").contains("export BUILDKITE_SAFE=safe"))
+        XCTAssertNil(scriptBuilder.environmentVariables[invalidName])
+        XCTAssertFalse(script.contains(invalidName))
+        XCTAssertEqual("safe", try readExportedVariable(named: "BUILDKITE_SAFE", fromScript: script))
+    }
+
     // MARK: - Shell-injection regression tests
     //
     // BUILDKITE_MESSAGE is attacker-controllable — its value is the head commit's

--- a/Tests/libhostmgrTests/BuildkiteScriptBuilderTests.swift
+++ b/Tests/libhostmgrTests/BuildkiteScriptBuilderTests.swift
@@ -206,18 +206,127 @@ class BuildkiteScriptBuilderTests: XCTestCase {
     ) throws {
         var builder = BuildkiteScriptBuilder()
         builder.addEnvironmentVariable(named: "BUILDKITE_TEST_VALUE", value: value)
-        let exportLine = builder.build()
+        let observed = try readExportedVariable(
+            named: "BUILDKITE_TEST_VALUE",
+            fromScript: builder.build(),
+            file: file,
+            line: line
+        )
+        XCTAssertEqual(
+            observed, value,
+            "value did not round-trip through the shell",
+            file: file, line: line
+        )
+    }
 
+}
+
+class BuildkiteScriptBuilderPathTests: XCTestCase {
+    func testThatLiteralPathValueDoesNotExtendExistingPath() throws {
+        // This documents the regression introduced by applying safe literal
+        // escaping to the hard-coded PATH expression from the buildkite-job
+        // generator. With normal environment variables, `$PATH` is deliberately
+        // kept literal and does not extend the shell's existing path.
+        var builder = BuildkiteScriptBuilder()
+        builder.addEnvironmentVariable(named: "PATH", value: "/opt/homebrew/bin:/opt/ci/bin:$PATH")
+
+        let observed = try readExportedVariable(
+            named: "PATH",
+            fromScript: builder.build(),
+            environment: ["PATH": "/usr/bin:/bin"]
+        )
+
+        XCTAssertEqual("/opt/homebrew/bin:/opt/ci/bin:$PATH", observed)
+        XCTAssertNotEqual("/opt/homebrew/bin:/opt/ci/bin:/usr/bin:/bin", observed)
+    }
+
+    func testThatPathPrependingValueExtendsExistingPath() throws {
+        var builder = BuildkiteScriptBuilder()
+        builder.addPathEnvironmentVariable(
+            named: "PATH",
+            prepending: ["/opt/homebrew/bin", "/opt/ci/bin"],
+            existingVariableName: "PATH"
+        )
+
+        let script = builder.build()
+        XCTAssertTrue(
+            script.components(separatedBy: "\n").contains("export PATH=/opt/homebrew/bin:/opt/ci/bin${PATH:+:$PATH}")
+        )
+
+        let observed = try readExportedVariable(
+            named: "PATH",
+            fromScript: script,
+            environment: ["PATH": "/usr/bin:/bin"]
+        )
+
+        XCTAssertEqual("/opt/homebrew/bin:/opt/ci/bin:/usr/bin:/bin", observed)
+    }
+
+    func testThatPathPrependingValueDoesNotAddEmptyPathEntryWhenExistingValueIsUnset() throws {
+        var builder = BuildkiteScriptBuilder()
+        builder.addPathEnvironmentVariable(
+            named: "HOSTMGR_PATH",
+            prepending: ["/opt/homebrew/bin", "/opt/ci/bin"],
+            existingVariableName: "HOSTMGR_EXISTING_PATH"
+        )
+
+        let observed = try readExportedVariable(
+            named: "HOSTMGR_PATH",
+            fromScript: builder.build(),
+            environment: ["PATH": "/usr/bin:/bin"]
+        )
+
+        XCTAssertEqual("/opt/homebrew/bin:/opt/ci/bin", observed)
+        XCTAssertNotEqual("/opt/homebrew/bin:/opt/ci/bin:", observed)
+    }
+
+    func testThatPathPrependingEscapesPathComponents() throws {
+        var builder = BuildkiteScriptBuilder()
+        builder.addPathEnvironmentVariable(
+            named: "PATH",
+            prepending: ["/Users/my user/bin", "/opt/ci/bin"],
+            existingVariableName: "PATH"
+        )
+
+        let script = builder.build()
+        XCTAssertTrue(
+            script.components(separatedBy: "\n")
+                .contains("export PATH='/Users/my user/bin':/opt/ci/bin${PATH:+:$PATH}")
+        )
+
+        let observed = try readExportedVariable(
+            named: "PATH",
+            fromScript: script,
+            environment: ["PATH": "/usr/bin:/bin"]
+        )
+
+        XCTAssertEqual("/Users/my user/bin:/opt/ci/bin:/usr/bin:/bin", observed)
+    }
+}
+
+extension XCTestCase {
+    fileprivate func readExportedVariable(
+        named variableName: String,
+        fromScript script: String,
+        environment: [String: String]? = nil,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws -> String {
         // Source the generated script and emit the variable verbatim, framed by
         // sentinels so we can extract it cleanly even if it contains newlines.
+        let sentinel = "HOSTMGR-\(UUID().uuidString)"
+        let startSentinel = "\(sentinel)-START"
+        let endSentinel = "\(sentinel)-END"
+
         let shellScript = """
-        \(exportLine)
-        printf '<<<%s>>>' "$BUILDKITE_TEST_VALUE"
+        \(script)
+        printf '%s%s%s' '\(startSentinel)' "$\(variableName)" '\(endSentinel)'
         """
 
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/bin/sh")
         process.arguments = ["-c", shellScript]
+        process.environment = environment
         let stdout = Pipe()
         let stderr = Pipe()
         process.standardOutput = stdout
@@ -241,20 +350,16 @@ class BuildkiteScriptBuilderTests: XCTestCase {
             file: file, line: line
         )
 
-        guard let start = stdoutText.range(of: "<<<"),
-              let end = stdoutText.range(of: ">>>", options: .backwards) else {
+        guard let start = stdoutText.range(of: startSentinel),
+              let end = stdoutText.range(of: endSentinel, options: .backwards) else {
             XCTFail(
                 "could not extract sentinel-framed value from stdout: \(stdoutText)",
                 file: file, line: line
             )
-            return
+            return ""
         }
-        let observed = String(stdoutText[start.upperBound..<end.lowerBound])
-        XCTAssertEqual(
-            observed, value,
-            "value did not round-trip through the shell",
-            file: file, line: line
-        )
+
+        return String(stdoutText[start.upperBound..<end.lowerBound])
     }
 }
 


### PR DESCRIPTION
## Summary

- Fix the Buildkite job generator's `PATH` export after #166 made normal environment values shell-safe literals.
- Add a narrow PATH-prepending env-var renderer that shell-escapes each path component and conditionally appends a validated existing variable reference with `${PATH:+:$PATH}`.
- Reject empty path components and components containing `:`, since PATH-like shell variables use `:` as their separator.

## Testing

- `swift test`
- Generated a `buildkite-job` script locally and confirmed it emits:

```sh
export PATH=/opt/homebrew/bin:/opt/ci/bin${PATH:+:$PATH}
```

## Regression Coverage

- `testThatLiteralPathValueDoesNotExtendExistingPath` demonstrates the broken post-#166 behavior: a normal literal env value keeps `$PATH` unexpanded.
- `testThatPathPrependingValueExtendsExistingPath` demonstrates the fix when the existing shell variable is set.
- `testThatPathPrependingValueDoesNotAddEmptyPathEntryWhenExistingValueIsUnset` avoids a trailing empty PATH component if the existing variable is unset.
- `testThatPathPrependingEscapesPathComponents` verifies path components with spaces are shell-escaped and concatenate correctly.
