### PR TITLE
Remove explicit `gem 'openssl'` from `Gemfile.lock`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,3 @@ gem 'fastlane', '~> 2.238'
 
 gem 'rubocop', '~> 1.89', require: false
 
-# only added to work around a Ruby 
-# failure that's present on the CI image
-# see: https://github.com/ruby/openssl/issues/949
-gem "openssl", "~> 4.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -186,7 +186,6 @@ GEM
     net-http (0.9.1)
       uri (>= 0.11.1)
     nkf (0.3.0)
-    openssl (4.0.2)
     optparse (0.8.1)
     os (1.1.4)
     ostruct (0.6.3)
@@ -283,7 +282,6 @@ PLATFORMS
 DEPENDENCIES
   aws-sdk-s3 (~> 1.229)
   fastlane (~> 2.238)
-  openssl (~> 4.0)
   rubocop (~> 1.89)
 
 BUNDLED WITH


### PR DESCRIPTION
This is no longer needed now that we use Ruby 3.4.9 (see #188)
