### PR TITLE
Retry VM SSH readiness checks and report Local Network denials

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,44 +56,16 @@ _(We can potentially automate this step, but for now this is still manual)_
 
 ## Troubleshooting VM startup
 
-`hostmgr vm start` waits for a TCP connection to the guest's SSH port (22). It retries
-while SSH is starting, with a 30-second overall deadline by default. If it times out, check the
-reported connection error and verify that Remote Login is enabled in the guest.
-Use `hostmgr vm details <handle> --ip-address` with the handle printed by `vm start`
-to confirm that you are testing the same VM address.
+`hostmgr vm start` retries the guest's SSH port (22) for up to 30 seconds by default.
+If it times out, check the reported error and ensure Remote Login is enabled in the
+guest. Use `hostmgr vm details <handle> --ip-address` to check the VM's address.
 
-### Local Network permission on the host
+For a Local Network denial, allow the app that launched `hostmgr` (such as your
+terminal or CI agent) in **System Settings > Privacy & Security > Local Network**
+on the **host Mac**. The SSH check runs in the CLI.
 
-A Local Network denial prevents the host's `hostmgr` process from reaching the
-guest. On the **host Mac**, allow the responsible launching app in
-**System Settings > Privacy & Security > Local Network**. This may be your terminal,
-IDE, or `buildkite-agent`. The SSH probe runs in the CLI, so granting permission
-only to `hostmgr-helper` may not address it.
-The check keeps waiting while you respond to a permission prompt and reports a
-specific error if access is still denied at the deadline.
-
-Apple documents exemptions for root and tools launched directly from Terminal.app
-or SSH, including children. `NSLocalNetworkUsageDescription` explains a prompt;
-it does not grant access. There is no per-binary exemption entitlement to add.
-
-macOS 15.5 and later support administrator-configured network exemptions. These
-allow **every program** to access the selected networks on Ethernet or Wi-Fi.
-Identify the VM network using `route -n get <VM-IP>` and `ifconfig <interface>`;
-verify its subnet and interface type. For example, **only if** the VM subnet is
-`192.168.64.0/24`:
-
-```sh
-VM_SUBNET="192.168.64.0/24"
-sudo defaults write com.apple.network.local-network AllowedEthernetLocalNetworkAddresses -array-add "$VM_SUBNET"
-sudo defaults write com.apple.network.local-network AllowedWiFiLocalNetworkAddresses -array-add "$VM_SUBNET"
-```
-
-The settings apply to their respective interface types and require a **host
-restart**. `-array-add` preserves existing entries. `hostmgr` does not apply these
-optional host settings automatically.
-
-See [Apple TN3179: Understanding local network privacy](https://developer.apple.com/documentation/technotes/tn3179-understanding-local-network-privacy)
-for permission attribution, network exemptions, and troubleshooting details.
+See [Apple TN3179](https://developer.apple.com/documentation/technotes/tn3179-understanding-local-network-privacy)
+for permission troubleshooting and administrator-managed subnet exemptions.
 
 ## Release
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,47 @@ _(We can potentially automate this step, but for now this is still manual)_
 1. Create a config file in `/opt/ci/hostmgr.json`. You can copy [the file we use to provision our macOS CI hosts](https://github.com/Automattic/buildkite-ci/blob/trunk/src/agents/macos-hosts/resources/hostmgr.json) _(Automattic internal link)_ directly there.
 1. Open a Terminal and run `hostmgr-helper` to launch the "hostmgr-helper" macOS app, which needs to be running during building VM images.
 
+## Troubleshooting VM startup
+
+`hostmgr vm start` waits for a TCP connection to the guest's SSH port (22). It retries
+while SSH is starting, with a 30-second overall deadline by default. If it times out, check the
+reported connection error and verify that Remote Login is enabled in the guest.
+Use `hostmgr vm details <handle> --ip-address` with the handle printed by `vm start`
+to confirm that you are testing the same VM address.
+
+### Local Network permission on the host
+
+A Local Network denial prevents the host's `hostmgr` process from reaching the
+guest. On the **host Mac**, allow the responsible launching app in
+**System Settings > Privacy & Security > Local Network**. This may be your terminal,
+IDE, or `buildkite-agent`. The SSH probe runs in the CLI, so granting permission
+only to `hostmgr-helper` may not address it.
+The check keeps waiting while you respond to a permission prompt and reports a
+specific error if access is still denied at the deadline.
+
+Apple documents exemptions for root and tools launched directly from Terminal.app
+or SSH, including children. `NSLocalNetworkUsageDescription` explains a prompt;
+it does not grant access. There is no per-binary exemption entitlement to add.
+
+macOS 15.5 and later support administrator-configured network exemptions. These
+allow **every program** to access the selected networks on Ethernet or Wi-Fi.
+Identify the VM network using `route -n get <VM-IP>` and `ifconfig <interface>`;
+verify its subnet and interface type. For example, **only if** the VM subnet is
+`192.168.64.0/24`:
+
+```sh
+VM_SUBNET="192.168.64.0/24"
+sudo defaults write com.apple.network.local-network AllowedEthernetLocalNetworkAddresses -array-add "$VM_SUBNET"
+sudo defaults write com.apple.network.local-network AllowedWiFiLocalNetworkAddresses -array-add "$VM_SUBNET"
+```
+
+The settings apply to their respective interface types and require a **host
+restart**. `-array-add` preserves existing entries. `hostmgr` does not apply these
+optional host settings automatically.
+
+See [Apple TN3179: Understanding local network privacy](https://developer.apple.com/documentation/technotes/tn3179-understanding-local-network-privacy)
+for permission attribution, network exemptions, and troubleshooting details.
+
 ## Release
 
 1. Create a PR to update [the version property](Sources/libhostmgr/libhostmgr.swift).

--- a/Sources/libhostmgr/CLI/HostmgrError.swift
+++ b/Sources/libhostmgr/CLI/HostmgrError.swift
@@ -72,8 +72,8 @@ public enum HostmgrError: Error, LocalizedError, Codable {
         case .sshAvailabilityTimeoutWithError(let error):
             return "Timeout while checking for the availability of the VM's SSH server. Last connection error: \(error)"
         case .sshLocalNetworkAccessDenied:
-            return "macOS denied Local Network access while checking the VM's SSH server. "
-                + "On the host Mac, allow the app that launched hostmgr (such as your terminal or CI agent) "
+            return "macOS denied Local Network access to the VM. "
+                + "On the host Mac, allow the app that launched hostmgr "
                 + "in System Settings > Privacy & Security > Local Network, then retry."
         }
     }

--- a/Sources/libhostmgr/CLI/HostmgrError.swift
+++ b/Sources/libhostmgr/CLI/HostmgrError.swift
@@ -21,6 +21,8 @@ public enum HostmgrError: Error, LocalizedError, Codable {
     case invalidVMSourceImage(URL)
     case xpcError(String)
     case sshAvailabilityTimeout
+    case sshAvailabilityTimeoutWithError(String)
+    case sshLocalNetworkAccessDenied
 
     public var errorDescription: String? {
         switch self {
@@ -67,6 +69,12 @@ public enum HostmgrError: Error, LocalizedError, Codable {
             return string
         case .sshAvailabilityTimeout:
             return "Timeout while checking for the availability of the VM's SSH server"
+        case .sshAvailabilityTimeoutWithError(let error):
+            return "Timeout while checking for the availability of the VM's SSH server. Last connection error: \(error)"
+        case .sshLocalNetworkAccessDenied:
+            return "macOS denied Local Network access while checking the VM's SSH server. "
+                + "On the host Mac, allow the app that launched hostmgr (such as your terminal or CI agent) "
+                + "in System Settings > Privacy & Security > Local Network, then retry."
         }
     }
 

--- a/Sources/libhostmgr/Platforms/SSHReadinessCheck.swift
+++ b/Sources/libhostmgr/Platforms/SSHReadinessCheck.swift
@@ -1,0 +1,138 @@
+import Foundation
+import Network
+import OSLog
+
+/// The connection callbacks must run on the queue passed to start(queue:).
+protocol SSHReadinessConnection: AnyObject {
+    var state: NWConnection.State { get }
+    var stateUpdateHandler: (@Sendable (NWConnection.State) -> Void)? { get set }
+    var isLocalNetworkDenied: Bool { get }
+    func start(queue: DispatchQueue)
+    func restart()
+    func cancel()
+}
+
+extension NWConnection: SSHReadinessConnection {
+    var isLocalNetworkDenied: Bool {
+        currentPath?.unsatisfiedReason == .localNetworkDenied
+    }
+}
+
+/// All mutable state, connection operations, and completion paths are confined to queue.
+final class SSHReadinessCheck: @unchecked Sendable {
+    private let queue = DispatchQueue(label: "com.automattic.hostmgr.ssh-readiness")
+    private let connection: SSHReadinessConnection
+    private var continuation: CheckedContinuation<Void, Error>?
+    private var deadlineTimer: DispatchSourceTimer?
+    private var retryTimer: DispatchSourceTimer?
+    private var lastWaitingError: NWError?
+    private var cancelled = false
+
+    private init(connection: SSHReadinessConnection) {
+        self.connection = connection
+    }
+
+    static func wait(
+        connection: SSHReadinessConnection,
+        timeout: Duration,
+        retryInterval: TimeInterval = 1
+    ) async throws {
+        let check = SSHReadinessCheck(connection: connection)
+        try await withTaskCancellationHandler {
+            try Task.checkCancellation()
+            try await withCheckedThrowingContinuation { continuation in
+                check.queue.async {
+                    check.start(continuation: continuation, timeout: timeout, retryInterval: retryInterval)
+                }
+            }
+        } onCancel: {
+            check.queue.async {
+                check.cancelled = true
+                check.finish(.failure(CancellationError()))
+            }
+        }
+    }
+
+    private func start(
+        continuation: CheckedContinuation<Void, Error>,
+        timeout: Duration,
+        retryInterval: TimeInterval
+    ) {
+        self.continuation = continuation
+        guard !cancelled else {
+            finish(.failure(CancellationError()))
+            return
+        }
+
+        connection.stateUpdateHandler = { [weak self] state in
+            self?.handle(state)
+        }
+
+        let seconds = Double(timeout.components.seconds) + Double(timeout.components.attoseconds) / 1e18
+        let deadlineTimer = DispatchSource.makeTimerSource(queue: queue)
+        deadlineTimer.schedule(deadline: .now() + max(0, seconds))
+        deadlineTimer.setEventHandler { [weak self] in
+            self?.timedOut()
+        }
+        self.deadlineTimer = deadlineTimer
+        deadlineTimer.resume()
+
+        // A refused connection can stay waiting forever without a path change. Explicitly
+        // restart waiting connections. A Local Network permission grant automatically retries
+        // a denied connection; leave it waiting so its denial reason remains available.
+        let retryTimer = DispatchSource.makeTimerSource(queue: queue)
+        retryTimer.schedule(deadline: .now() + retryInterval, repeating: retryInterval)
+        retryTimer.setEventHandler { [weak self] in
+            guard let self, self.continuation != nil, case .waiting = self.connection.state,
+                  !self.connection.isLocalNetworkDenied else { return }
+            self.connection.restart()
+        }
+        self.retryTimer = retryTimer
+        retryTimer.resume()
+
+        connection.start(queue: queue)
+    }
+
+    private func handle(_ state: NWConnection.State) {
+        guard continuation != nil else { return }
+        switch state {
+        case .ready:
+            finish(.success(()))
+        case .waiting(let error):
+            lastWaitingError = error
+            Logger.lib.debug("""
+                Waiting for the VM's SSH server: \(String(describing: error)), \
+                localNetworkDenied: \(self.connection.isLocalNetworkDenied)
+                """)
+        case .failed(let error):
+            finish(.failure(error))
+        case .cancelled:
+            finish(.failure(CancellationError()))
+        default:
+            break
+        }
+    }
+
+    private func timedOut() {
+        // Check the current path so a previous denial does not mask a subsequent problem.
+        if connection.isLocalNetworkDenied {
+            finish(.failure(HostmgrError.sshLocalNetworkAccessDenied))
+        } else if let lastWaitingError {
+            finish(.failure(HostmgrError.sshAvailabilityTimeoutWithError(String(describing: lastWaitingError))))
+        } else {
+            finish(.failure(HostmgrError.sshAvailabilityTimeout))
+        }
+    }
+
+    private func finish(_ result: Result<Void, Error>) {
+        guard let continuation else { return }
+        self.continuation = nil
+        deadlineTimer?.cancel()
+        deadlineTimer = nil
+        retryTimer?.cancel()
+        retryTimer = nil
+        connection.stateUpdateHandler = nil
+        connection.cancel()
+        continuation.resume(with: result)
+    }
+}

--- a/Sources/libhostmgr/Platforms/SSHReadinessCheck.swift
+++ b/Sources/libhostmgr/Platforms/SSHReadinessCheck.swift
@@ -2,7 +2,7 @@ import Foundation
 import Network
 import OSLog
 
-/// The connection callbacks must run on the queue passed to start(queue:).
+/// Callbacks run on the queue passed to start(queue:).
 protocol SSHReadinessConnection: AnyObject {
     var state: NWConnection.State { get }
     var stateUpdateHandler: (@Sendable (NWConnection.State) -> Void)? { get set }
@@ -18,7 +18,7 @@ extension NWConnection: SSHReadinessConnection {
     }
 }
 
-/// All mutable state, connection operations, and completion paths are confined to queue.
+/// All state and connection operations are confined to queue.
 final class SSHReadinessCheck: @unchecked Sendable {
     private let queue = DispatchQueue(label: "com.automattic.hostmgr.ssh-readiness")
     private let connection: SSHReadinessConnection
@@ -39,7 +39,6 @@ final class SSHReadinessCheck: @unchecked Sendable {
     ) async throws {
         let check = SSHReadinessCheck(connection: connection)
         try await withTaskCancellationHandler {
-            try Task.checkCancellation()
             try await withCheckedThrowingContinuation { continuation in
                 check.queue.async {
                     check.start(continuation: continuation, timeout: timeout, retryInterval: retryInterval)
@@ -77,9 +76,8 @@ final class SSHReadinessCheck: @unchecked Sendable {
         self.deadlineTimer = deadlineTimer
         deadlineTimer.resume()
 
-        // A refused connection can stay waiting forever without a path change. Explicitly
-        // restart waiting connections. A Local Network permission grant automatically retries
-        // a denied connection; leave it waiting so its denial reason remains available.
+        // Refusals need retries without a path change. Leave denied connections waiting:
+        // permission grants retry them automatically, and a restart could hide the denial.
         let retryTimer = DispatchSource.makeTimerSource(queue: queue)
         retryTimer.schedule(deadline: .now() + retryInterval, repeating: retryInterval)
         retryTimer.setEventHandler { [weak self] in
@@ -100,10 +98,7 @@ final class SSHReadinessCheck: @unchecked Sendable {
             finish(.success(()))
         case .waiting(let error):
             lastWaitingError = error
-            Logger.lib.debug("""
-                Waiting for the VM's SSH server: \(String(describing: error)), \
-                localNetworkDenied: \(self.connection.isLocalNetworkDenied)
-                """)
+            Logger.lib.debug("Waiting for VM SSH: \(error), localNetworkDenied: \(connection.isLocalNetworkDenied)")
         case .failed(let error):
             finish(.failure(error))
         case .cancelled:
@@ -114,7 +109,7 @@ final class SSHReadinessCheck: @unchecked Sendable {
     }
 
     private func timedOut() {
-        // Check the current path so a previous denial does not mask a subsequent problem.
+        // The current path reflects permission changes during the wait.
         if connection.isLocalNetworkDenied {
             finish(.failure(HostmgrError.sshLocalNetworkAccessDenied))
         } else if let lastWaitingError {

--- a/Sources/libhostmgr/Platforms/VMManager.swift
+++ b/Sources/libhostmgr/Platforms/VMManager.swift
@@ -240,27 +240,8 @@ extension VMManager {
     }
 
     func waitForSSHServer(forAddress address: IPv4Address, timeout: Duration) async throws {
+        Logger.lib.debug("Checking the VM's SSH server at \(String(describing: address)):22")
         let connection = NWConnection(to: .hostPort(host: .ipv4(address), port: 22), using: .tcp)
-
-        return try await withCheckedThrowingContinuation { continuation in
-            connection.stateUpdateHandler = {newState in
-                switch newState {
-                case .ready:
-                    continuation.resume()
-                case .failed(let error):
-                    continuation.resume(throwing: error)
-                case .cancelled:
-                    continuation.resume(throwing: HostmgrError.sshAvailabilityTimeout)
-                default:
-                    break
-                }
-            }
-
-            DispatchQueue.global().asyncAfter(deadline: .now() + TimeInterval(timeout.components.seconds)) {
-                connection.cancel()
-            }
-
-            connection.start(queue: .main)
-        }
+        try await SSHReadinessCheck.wait(connection: connection, timeout: timeout)
     }
 }

--- a/Tests/libhostmgrTests/Model/GitMirrorTests.swift
+++ b/Tests/libhostmgrTests/Model/GitMirrorTests.swift
@@ -46,7 +46,9 @@ final class GitMirrorTests: XCTestCase {
     }
 
     func testRemoveArchiveDeletesFile() throws {
+        let subject = GitMirror(url: URL(string: "https://example.com/test-\(UUID().uuidString).git")!)
         let archivePath = subject.archivePath
+        defer { try? FileManager.default.removeItem(at: archivePath) }
         try FileManager.default.createDirectory(
             at: archivePath.deletingLastPathComponent(),
             withIntermediateDirectories: true
@@ -59,6 +61,7 @@ final class GitMirrorTests: XCTestCase {
     }
 
     func testRemoveArchiveSucceedsWhenFileDoesNotExist() throws {
+        let subject = GitMirror(url: URL(string: "https://example.com/test-\(UUID().uuidString).git")!)
         XCTAssertFalse(FileManager.default.fileExists(atPath: subject.archivePath.path))
         XCTAssertNoThrow(try subject.removeArchive())
     }

--- a/Tests/libhostmgrTests/Platforms/SSHReadinessCheckTests.swift
+++ b/Tests/libhostmgrTests/Platforms/SSHReadinessCheckTests.swift
@@ -3,7 +3,7 @@ import Network
 @testable import libhostmgr
 
 final class SSHReadinessCheckTests: XCTestCase {
-    func testConnectsWhenListenerStartsAfterFirstRefusal() async throws {
+    func testConnectsWhenListenerStartsAfterRefusal() async throws {
         let listener = try DeferredTCPListener()
         defer { listener.close() }
         let refused = expectation(description: "Initial connection was refused")
@@ -20,23 +20,22 @@ final class SSHReadinessCheckTests: XCTestCase {
         XCTAssertNil(connection.connection.stateUpdateHandler)
     }
 
-    func testSuccessCleansUpAndIgnoresQueuedCallbacksAndOriginalDeadline() async throws {
+    func testSuccessIgnoresLateCallbacksAndDeadline() async throws {
         let connection = StubSSHConnection(state: .ready)
         connection.onStart = { connection in
-            // These callbacks were queued before cleanup and still hold the original handler.
+            // Queued callbacks retain the handler even after cleanup.
             connection.emit(.failed(.posix(.ECONNRESET)))
             connection.emit(.cancelled)
         }
 
         try await SSHReadinessCheck.wait(connection: connection, timeout: .milliseconds(80), retryInterval: 0.01)
-        XCTAssertEqual(connection.cancelCount, 1)
-        XCTAssertFalse(connection.hasHandler)
+        assertCleanedUp(connection)
         try await Task.sleep(for: .milliseconds(150))
         XCTAssertEqual(connection.cancelCount, 1)
         XCTAssertEqual(connection.restartCount, 0)
     }
 
-    func testDeadlinePreservesFractionalDurationAndDoesNotRestartPreparingConnection() async {
+    func testPreparingConnectionWaitsForFractionalDeadline() async {
         let connection = StubSSHConnection(state: .preparing)
         let start = ContinuousClock.now
         let error = await failure(connection, timeout: .milliseconds(100))
@@ -50,22 +49,23 @@ final class SSHReadinessCheckTests: XCTestCase {
         assertCleanedUp(connection)
     }
 
-    func testRetriesShareOneDeadlineAndReportMostRecentWaitingError() async {
+    func testRetriesPreserveDeadlineAndLatestError() async {
         let connection = StubSSHConnection(state: .waiting(.posix(.ECONNREFUSED)))
-        connection.onRestart = { $0.emit(.waiting(.posix(.ETIMEDOUT))) }
+        // A permission errno alone must not be diagnosed as Local Network denial.
+        connection.onRestart = { $0.emit(.waiting(.posix(.EACCES))) }
         let start = ContinuousClock.now
         let error = await failure(connection, timeout: .milliseconds(100))
 
         guard case HostmgrError.sshAvailabilityTimeoutWithError(let details) = error else {
             return XCTFail("Expected timeout with waiting error, got \(error)")
         }
-        XCTAssertEqual(details, String(describing: NWError.posix(.ETIMEDOUT)))
+        XCTAssertEqual(details, String(describing: NWError.posix(.EACCES)))
         XCTAssertGreaterThan(connection.restartCount, 0)
         XCTAssertLessThan(start.duration(to: .now), .seconds(2))
         assertCleanedUp(connection)
     }
 
-    func testTerminalFailureIsPropagatedAndCleansUp() async {
+    func testPropagatesTerminalFailure() async {
         let connection = StubSSHConnection(state: .failed(.posix(.ECONNRESET)))
         let error = await failure(connection, timeout: .seconds(5))
 
@@ -74,7 +74,7 @@ final class SSHReadinessCheckTests: XCTestCase {
         assertCleanedUp(connection)
     }
 
-    func testCancellationBeforeWaitingDoesNotStartConnection() async {
+    func testCancellationBeforeStart() async {
         let connection = StubSSHConnection(state: .waiting(.posix(.ECONNREFUSED)))
         let task = Task {
             withUnsafeCurrentTask { $0?.cancel() }
@@ -85,10 +85,10 @@ final class SSHReadinessCheckTests: XCTestCase {
         XCTAssertTrue(error is CancellationError)
         XCTAssertEqual(connection.startCount, 0)
         XCTAssertEqual(connection.restartCount, 0)
-        XCTAssertFalse(connection.hasHandler)
+        assertCleanedUp(connection)
     }
 
-    func testCancellationWhileWaitingCleansUpPromptly() async {
+    func testCancellationWhileWaiting() async {
         let started = expectation(description: "Connection started")
         let connection = StubSSHConnection(state: .waiting(.posix(.ECONNREFUSED)))
         connection.onStart = { _ in started.fulfill() }
@@ -104,7 +104,7 @@ final class SSHReadinessCheckTests: XCTestCase {
         assertCleanedUp(connection)
     }
 
-    func testPersistentPrivacyDenialWaitsUntilDeadlineAndExplainsHostPermission() async {
+    func testPermissionDenialWaitsForDeadline() async {
         let connection = StubSSHConnection(state: .waiting(.posix(.EACCES)), denied: true)
         let start = ContinuousClock.now
         let error = await failure(connection, timeout: .milliseconds(100))
@@ -114,13 +114,10 @@ final class SSHReadinessCheckTests: XCTestCase {
         }
         XCTAssertGreaterThanOrEqual(start.duration(to: .now), .milliseconds(80))
         XCTAssertEqual(connection.restartCount, 0)
-        XCTAssertTrue(error.localizedDescription.contains("host Mac"))
-        XCTAssertTrue(error.localizedDescription.contains("app that launched hostmgr"))
-        XCTAssertTrue(error.localizedDescription.contains("Privacy & Security > Local Network"))
         assertCleanedUp(connection)
     }
 
-    func testGrantingPermissionWhileWaitingCanRecover() async throws {
+    func testPermissionGrantAllowsConnection() async throws {
         let connection = StubSSHConnection(state: .waiting(.posix(.EACCES)), denied: true)
         connection.onStart = { connection in
             connection.performAfter(0.03) {
@@ -135,7 +132,7 @@ final class SSHReadinessCheckTests: XCTestCase {
         assertCleanedUp(connection)
     }
 
-    func testClearedPrivacyDenialDoesNotMaskLaterConnectionProblem() async {
+    func testClearedDenialReportsConnectionError() async {
         let connection = StubSSHConnection(state: .waiting(.posix(.EACCES)), denied: true)
         connection.onStart = { connection in
             connection.performAfter(0.03) {
@@ -152,17 +149,6 @@ final class SSHReadinessCheckTests: XCTestCase {
         assertCleanedUp(connection)
     }
 
-    func testPermissionErrnoAloneIsNotClassifiedAsLocalNetworkDenial() async {
-        let connection = StubSSHConnection(state: .waiting(.posix(.EACCES)))
-        let error = await failure(connection, timeout: .milliseconds(80))
-
-        guard case HostmgrError.sshAvailabilityTimeoutWithError(let details) = error else {
-            return XCTFail("Expected ordinary timeout without a privacy path reason, got \(error)")
-        }
-        XCTAssertEqual(details, String(describing: NWError.posix(.EACCES)))
-        assertCleanedUp(connection)
-    }
-
     private func failure(_ connection: StubSSHConnection, timeout: Duration) async -> Error {
         do {
             try await SSHReadinessCheck.wait(connection: connection, timeout: timeout, retryInterval: 0.01)
@@ -175,7 +161,7 @@ final class SSHReadinessCheckTests: XCTestCase {
 
     private func assertCleanedUp(_ connection: StubSSHConnection, file: StaticString = #filePath, line: UInt = #line) {
         XCTAssertEqual(connection.cancelCount, 1, file: file, line: line)
-        XCTAssertFalse(connection.hasHandler, file: file, line: line)
+        XCTAssertNil(connection.stateUpdateHandler, file: file, line: line)
     }
 
     private struct UnexpectedSuccess: Error {}

--- a/Tests/libhostmgrTests/Platforms/SSHReadinessCheckTests.swift
+++ b/Tests/libhostmgrTests/Platforms/SSHReadinessCheckTests.swift
@@ -1,0 +1,182 @@
+import XCTest
+import Network
+@testable import libhostmgr
+
+final class SSHReadinessCheckTests: XCTestCase {
+    func testConnectsWhenListenerStartsAfterFirstRefusal() async throws {
+        let listener = try DeferredTCPListener()
+        defer { listener.close() }
+        let refused = expectation(description: "Initial connection was refused")
+        let connection = ObservedSSHConnection(port: listener.port) { error in
+            XCTAssertEqual(error, .posix(.ECONNREFUSED))
+            refused.fulfill()
+            XCTAssertEqual(listener.listen(), 0)
+        }
+
+        try await SSHReadinessCheck.wait(connection: connection, timeout: .seconds(3), retryInterval: 0.05)
+
+        await fulfillment(of: [refused], timeout: 1)
+        XCTAssertNil(connection.stateUpdateHandler)
+        XCTAssertNil(connection.connection.stateUpdateHandler)
+    }
+
+    func testSuccessCleansUpAndIgnoresQueuedCallbacksAndOriginalDeadline() async throws {
+        let connection = StubSSHConnection(state: .ready)
+        connection.onStart = { connection in
+            // These callbacks were queued before cleanup and still hold the original handler.
+            connection.emit(.failed(.posix(.ECONNRESET)))
+            connection.emit(.cancelled)
+        }
+
+        try await SSHReadinessCheck.wait(connection: connection, timeout: .milliseconds(80), retryInterval: 0.01)
+        XCTAssertEqual(connection.cancelCount, 1)
+        XCTAssertFalse(connection.hasHandler)
+        try await Task.sleep(for: .milliseconds(150))
+        XCTAssertEqual(connection.cancelCount, 1)
+        XCTAssertEqual(connection.restartCount, 0)
+    }
+
+    func testDeadlinePreservesFractionalDurationAndDoesNotRestartPreparingConnection() async {
+        let connection = StubSSHConnection(state: .preparing)
+        let start = ContinuousClock.now
+        let error = await failure(connection, timeout: .milliseconds(100))
+
+        guard case HostmgrError.sshAvailabilityTimeout = error else {
+            return XCTFail("Expected timeout, got \(error)")
+        }
+        XCTAssertGreaterThanOrEqual(start.duration(to: .now), .milliseconds(80))
+        XCTAssertLessThan(start.duration(to: .now), .seconds(2))
+        XCTAssertEqual(connection.restartCount, 0)
+        assertCleanedUp(connection)
+    }
+
+    func testRetriesShareOneDeadlineAndReportMostRecentWaitingError() async {
+        let connection = StubSSHConnection(state: .waiting(.posix(.ECONNREFUSED)))
+        connection.onRestart = { $0.emit(.waiting(.posix(.ETIMEDOUT))) }
+        let start = ContinuousClock.now
+        let error = await failure(connection, timeout: .milliseconds(100))
+
+        guard case HostmgrError.sshAvailabilityTimeoutWithError(let details) = error else {
+            return XCTFail("Expected timeout with waiting error, got \(error)")
+        }
+        XCTAssertEqual(details, String(describing: NWError.posix(.ETIMEDOUT)))
+        XCTAssertGreaterThan(connection.restartCount, 0)
+        XCTAssertLessThan(start.duration(to: .now), .seconds(2))
+        assertCleanedUp(connection)
+    }
+
+    func testTerminalFailureIsPropagatedAndCleansUp() async {
+        let connection = StubSSHConnection(state: .failed(.posix(.ECONNRESET)))
+        let error = await failure(connection, timeout: .seconds(5))
+
+        XCTAssertEqual(error as? NWError, .posix(.ECONNRESET))
+        XCTAssertEqual(connection.restartCount, 0)
+        assertCleanedUp(connection)
+    }
+
+    func testCancellationBeforeWaitingDoesNotStartConnection() async {
+        let connection = StubSSHConnection(state: .waiting(.posix(.ECONNREFUSED)))
+        let task = Task {
+            withUnsafeCurrentTask { $0?.cancel() }
+            return await self.failure(connection, timeout: .seconds(5))
+        }
+        let error = await task.value
+
+        XCTAssertTrue(error is CancellationError)
+        XCTAssertEqual(connection.startCount, 0)
+        XCTAssertEqual(connection.restartCount, 0)
+        XCTAssertFalse(connection.hasHandler)
+    }
+
+    func testCancellationWhileWaitingCleansUpPromptly() async {
+        let started = expectation(description: "Connection started")
+        let connection = StubSSHConnection(state: .waiting(.posix(.ECONNREFUSED)))
+        connection.onStart = { _ in started.fulfill() }
+        let task = Task { await self.failure(connection, timeout: .seconds(5)) }
+        await fulfillment(of: [started], timeout: 1)
+
+        let start = ContinuousClock.now
+        task.cancel()
+        let error = await task.value
+
+        XCTAssertTrue(error is CancellationError)
+        XCTAssertLessThan(start.duration(to: .now), .seconds(1))
+        assertCleanedUp(connection)
+    }
+
+    func testPersistentPrivacyDenialWaitsUntilDeadlineAndExplainsHostPermission() async {
+        let connection = StubSSHConnection(state: .waiting(.posix(.EACCES)), denied: true)
+        let start = ContinuousClock.now
+        let error = await failure(connection, timeout: .milliseconds(100))
+
+        guard case HostmgrError.sshLocalNetworkAccessDenied = error else {
+            return XCTFail("Expected Local Network denial, got \(error)")
+        }
+        XCTAssertGreaterThanOrEqual(start.duration(to: .now), .milliseconds(80))
+        XCTAssertEqual(connection.restartCount, 0)
+        XCTAssertTrue(error.localizedDescription.contains("host Mac"))
+        XCTAssertTrue(error.localizedDescription.contains("app that launched hostmgr"))
+        XCTAssertTrue(error.localizedDescription.contains("Privacy & Security > Local Network"))
+        assertCleanedUp(connection)
+    }
+
+    func testGrantingPermissionWhileWaitingCanRecover() async throws {
+        let connection = StubSSHConnection(state: .waiting(.posix(.EACCES)), denied: true)
+        connection.onStart = { connection in
+            connection.performAfter(0.03) {
+                connection.isLocalNetworkDenied = false
+                connection.emit(.ready)
+            }
+        }
+
+        try await SSHReadinessCheck.wait(connection: connection, timeout: .seconds(1), retryInterval: 0.01)
+
+        XCTAssertEqual(connection.restartCount, 0)
+        assertCleanedUp(connection)
+    }
+
+    func testClearedPrivacyDenialDoesNotMaskLaterConnectionProblem() async {
+        let connection = StubSSHConnection(state: .waiting(.posix(.EACCES)), denied: true)
+        connection.onStart = { connection in
+            connection.performAfter(0.03) {
+                connection.isLocalNetworkDenied = false
+                connection.emit(.waiting(.posix(.ECONNREFUSED)))
+            }
+        }
+        let error = await failure(connection, timeout: .milliseconds(100))
+
+        guard case HostmgrError.sshAvailabilityTimeoutWithError(let details) = error else {
+            return XCTFail("Expected ordinary timeout after permission recovered, got \(error)")
+        }
+        XCTAssertEqual(details, String(describing: NWError.posix(.ECONNREFUSED)))
+        assertCleanedUp(connection)
+    }
+
+    func testPermissionErrnoAloneIsNotClassifiedAsLocalNetworkDenial() async {
+        let connection = StubSSHConnection(state: .waiting(.posix(.EACCES)))
+        let error = await failure(connection, timeout: .milliseconds(80))
+
+        guard case HostmgrError.sshAvailabilityTimeoutWithError(let details) = error else {
+            return XCTFail("Expected ordinary timeout without a privacy path reason, got \(error)")
+        }
+        XCTAssertEqual(details, String(describing: NWError.posix(.EACCES)))
+        assertCleanedUp(connection)
+    }
+
+    private func failure(_ connection: StubSSHConnection, timeout: Duration) async -> Error {
+        do {
+            try await SSHReadinessCheck.wait(connection: connection, timeout: timeout, retryInterval: 0.01)
+            XCTFail("Expected the readiness check to fail")
+            return UnexpectedSuccess()
+        } catch {
+            return error
+        }
+    }
+
+    private func assertCleanedUp(_ connection: StubSSHConnection, file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertEqual(connection.cancelCount, 1, file: file, line: line)
+        XCTAssertFalse(connection.hasHandler, file: file, line: line)
+    }
+
+    private struct UnexpectedSuccess: Error {}
+}

--- a/Tests/libhostmgrTests/Platforms/SSHReadinessTestSupport.swift
+++ b/Tests/libhostmgrTests/Platforms/SSHReadinessTestSupport.swift
@@ -3,7 +3,7 @@ import Network
 import Darwin
 @testable import libhostmgr
 
-/// State shared with the test task is locked; callbacks run on the readiness queue.
+/// Shared state is locked; callbacks run on the readiness queue.
 final class StubSSHConnection: SSHReadinessConnection, @unchecked Sendable {
     private let lock = NSLock()
     private var callbackQueue: DispatchQueue?
@@ -14,7 +14,7 @@ final class StubSSHConnection: SSHReadinessConnection, @unchecked Sendable {
     private var restarts = 0
     private var cancels = 0
 
-    // Configure these before passing the connection to the readiness check.
+    // Configure before starting the check.
     var onStart: ((StubSSHConnection) -> Void)?
     var onRestart: ((StubSSHConnection) -> Void)?
 
@@ -27,7 +27,6 @@ final class StubSSHConnection: SSHReadinessConnection, @unchecked Sendable {
     var startCount: Int { lock.withLock { starts } }
     var restartCount: Int { lock.withLock { restarts } }
     var cancelCount: Int { lock.withLock { cancels } }
-    var hasHandler: Bool { lock.withLock { handler != nil } }
 
     var stateUpdateHandler: (@Sendable (NWConnection.State) -> Void)? {
         get { lock.withLock { handler } }
@@ -58,7 +57,7 @@ final class StubSSHConnection: SSHReadinessConnection, @unchecked Sendable {
         emit(.cancelled)
     }
 
-    /// Keep simulated path and state changes atomic relative to the readiness timers.
+    /// Serialize path and state changes with readiness timers.
     func performAfter(_ delay: TimeInterval, _ update: @escaping @Sendable () -> Void) {
         let queue = lock.withLock { callbackQueue }
         queue?.asyncAfter(deadline: .now() + delay, execute: update)
@@ -73,7 +72,7 @@ final class StubSSHConnection: SSHReadinessConnection, @unchecked Sendable {
     }
 }
 
-/// Starts the real listener only once a real NWConnection has received a refusal.
+/// Observes the first refusal before starting the listener.
 final class ObservedSSHConnection: SSHReadinessConnection {
     let connection: NWConnection
     private let onFirstWaiting: (NWError) -> Void
@@ -147,7 +146,7 @@ final class DeferredTCPListener {
                 bind(descriptor, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
             }
         }
-        // Report a bind failure if another process claimed this ephemeral port in the meantime.
+        // Fail if another process claimed the port.
         return result == 0 ? Darwin.listen(descriptor, 1) : result
     }
     func close() { Darwin.close(descriptor) }

--- a/Tests/libhostmgrTests/Platforms/SSHReadinessTestSupport.swift
+++ b/Tests/libhostmgrTests/Platforms/SSHReadinessTestSupport.swift
@@ -1,0 +1,156 @@
+import Foundation
+import Network
+import Darwin
+@testable import libhostmgr
+
+/// State shared with the test task is locked; callbacks run on the readiness queue.
+final class StubSSHConnection: SSHReadinessConnection, @unchecked Sendable {
+    private let lock = NSLock()
+    private var callbackQueue: DispatchQueue?
+    private var handler: (@Sendable (NWConnection.State) -> Void)?
+    private var currentState: NWConnection.State
+    private var denied: Bool
+    private var starts = 0
+    private var restarts = 0
+    private var cancels = 0
+
+    // Configure these before passing the connection to the readiness check.
+    var onStart: ((StubSSHConnection) -> Void)?
+    var onRestart: ((StubSSHConnection) -> Void)?
+
+    init(state: NWConnection.State, denied: Bool = false) {
+        currentState = state
+        self.denied = denied
+    }
+
+    var state: NWConnection.State { lock.withLock { currentState } }
+    var startCount: Int { lock.withLock { starts } }
+    var restartCount: Int { lock.withLock { restarts } }
+    var cancelCount: Int { lock.withLock { cancels } }
+    var hasHandler: Bool { lock.withLock { handler != nil } }
+
+    var stateUpdateHandler: (@Sendable (NWConnection.State) -> Void)? {
+        get { lock.withLock { handler } }
+        set { lock.withLock { handler = newValue } }
+    }
+
+    var isLocalNetworkDenied: Bool {
+        get { lock.withLock { denied } }
+        set { lock.withLock { denied = newValue } }
+    }
+
+    func start(queue: DispatchQueue) {
+        lock.withLock {
+            callbackQueue = queue
+            starts += 1
+        }
+        emit(state)
+        onStart?(self)
+    }
+
+    func restart() {
+        lock.withLock { restarts += 1 }
+        onRestart?(self)
+    }
+
+    func cancel() {
+        lock.withLock { cancels += 1 }
+        emit(.cancelled)
+    }
+
+    /// Keep simulated path and state changes atomic relative to the readiness timers.
+    func performAfter(_ delay: TimeInterval, _ update: @escaping @Sendable () -> Void) {
+        let queue = lock.withLock { callbackQueue }
+        queue?.asyncAfter(deadline: .now() + delay, execute: update)
+    }
+
+    func emit(_ state: NWConnection.State) {
+        let (queue, callback) = lock.withLock {
+            currentState = state
+            return (callbackQueue, handler)
+        }
+        queue?.async { callback?(state) }
+    }
+}
+
+/// Starts the real listener only once a real NWConnection has received a refusal.
+final class ObservedSSHConnection: SSHReadinessConnection {
+    let connection: NWConnection
+    private let onFirstWaiting: (NWError) -> Void
+    private var observedWaiting = false
+
+    init(port: UInt16, onFirstWaiting: @escaping (NWError) -> Void) {
+        connection = NWConnection(host: .ipv4(.loopback), port: NWEndpoint.Port(rawValue: port)!, using: .tcp)
+        self.onFirstWaiting = onFirstWaiting
+    }
+
+    var state: NWConnection.State { connection.state }
+    var isLocalNetworkDenied: Bool { connection.isLocalNetworkDenied }
+    var stateUpdateHandler: (@Sendable (NWConnection.State) -> Void)? {
+        didSet {
+            guard let stateUpdateHandler else {
+                connection.stateUpdateHandler = nil
+                return
+            }
+            connection.stateUpdateHandler = { [weak self] state in
+                if let self, case .waiting(let error) = state, !self.observedWaiting {
+                    self.observedWaiting = true
+                    self.onFirstWaiting(error)
+                }
+                stateUpdateHandler(state)
+            }
+        }
+    }
+
+    func start(queue: DispatchQueue) { connection.start(queue: queue) }
+    func restart() { connection.restart() }
+    func cancel() { connection.cancel() }
+}
+
+/// Choose an unused loopback port, then release it so the first connection is refused.
+final class DeferredTCPListener {
+    private let descriptor: Int32
+    let port: UInt16
+
+    init() throws {
+        let descriptor = socket(AF_INET, SOCK_STREAM, 0)
+        guard descriptor >= 0 else { throw SocketSetupError() }
+        var address = sockaddr_in()
+        address.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+        address.sin_family = sa_family_t(AF_INET)
+        address.sin_addr.s_addr = INADDR_LOOPBACK.bigEndian
+        var length = socklen_t(MemoryLayout<sockaddr_in>.size)
+        let result = withUnsafeMutablePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                guard bind(descriptor, $0, length) == 0 else { return Int32(-1) }
+                return getsockname(descriptor, $0, &length)
+            }
+        }
+        guard result == 0 else {
+            Darwin.close(descriptor)
+            throw SocketSetupError()
+        }
+        port = UInt16(bigEndian: address.sin_port)
+        Darwin.close(descriptor)
+        self.descriptor = socket(AF_INET, SOCK_STREAM, 0)
+        guard self.descriptor >= 0 else { throw SocketSetupError() }
+    }
+
+    func listen() -> Int32 {
+        var address = sockaddr_in()
+        address.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+        address.sin_family = sa_family_t(AF_INET)
+        address.sin_addr.s_addr = INADDR_LOOPBACK.bigEndian
+        address.sin_port = port.bigEndian
+        let result = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                bind(descriptor, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        // Report a bind failure if another process claimed this ephemeral port in the meantime.
+        return result == 0 ? Darwin.listen(descriptor, 1) : result
+    }
+    func close() { Darwin.close(descriptor) }
+
+    private struct SocketSetupError: Error {}
+}

--- a/Tests/libhostmgrTests/Platforms/SSHReadinessTestSupport.swift
+++ b/Tests/libhostmgrTests/Platforms/SSHReadinessTestSupport.swift
@@ -106,7 +106,8 @@ final class ObservedSSHConnection: SSHReadinessConnection {
     func cancel() { connection.cancel() }
 }
 
-/// Choose an unused loopback port, then release it so the first connection is refused.
+/// Release the port to get ECONNREFUSED; a bound, non-listening socket can leave
+/// NWConnection preparing on macOS.
 final class DeferredTCPListener {
     private let descriptor: Int32
     let port: UInt16

--- a/Tests/libhostmgrTests/Platforms/VMManagerTests.swift
+++ b/Tests/libhostmgrTests/Platforms/VMManagerTests.swift
@@ -6,7 +6,7 @@ final class VMManagerTests: XCTestCase {
 
     /// Test that unpackVM throws the correct error when a VM already exists at the destination
     func testUnpackVMThrowsWhenVMAlreadyExists() async throws {
-        let vmName = "test-vm"
+        let vmName = "test-vm-\(UUID().uuidString)"
         let expectedVMPath = Paths.toVMTemplate(named: vmName)
 
         // Create the destination directory to simulate an existing VM
@@ -27,7 +27,7 @@ final class VMManagerTests: XCTestCase {
 
     /// Test that unpackVM throws an error when the source archive doesn't exist
     func testUnpackVMThrowsWhenArchiveDoesNotExist() async throws {
-        let vmName = "non-existent-vm"
+        let vmName = "non-existent-vm-\(UUID().uuidString)"
         let vmManager = VMManager()
 
         do {
@@ -40,7 +40,7 @@ final class VMManagerTests: XCTestCase {
 
     /// Test that temporary directories are properly cleaned up when unpackVM fails
     func testUnpackVMCleansUpTempDirectoryOnFailure() async throws {
-        let vmName = "test-vm-cleanup"
+        let vmName = "test-vm-cleanup-\(UUID().uuidString)"
         let vmManager = VMManager()
 
         do {
@@ -59,7 +59,7 @@ final class VMManagerTests: XCTestCase {
 
     /// Test that when unpacking an invalid archive fails, no folder is left at the final destination
     func testUnpackVMDoesNotLeaveDestinationFolderOnInvalidArchive() async throws {
-        let vmName = "test-invalid-archive"
+        let vmName = "test-invalid-archive-\(UUID().uuidString)"
         let archivePath = Paths.toArchivedVM(named: vmName)
         let finalDestination = Paths.toVMTemplate(named: vmName)
 
@@ -71,7 +71,7 @@ final class VMManagerTests: XCTestCase {
         try "invalid archive content".write(to: archivePath, atomically: true, encoding: .utf8)
 
         defer {
-            try? FileManager.default.removeItem(at: archivePath.deletingLastPathComponent())
+            try? FileManager.default.removeItem(at: archivePath)
             try? FileManager.default.removeItem(at: finalDestination)
         }
 


### PR DESCRIPTION
After running some local codex checks, it noticed `hostmgr vm start` can time out even after SSH becomes reachable because refused connections remain waiting without a retry, preventing Packer from starting provisioning, while Local Network denials are hidden behind the same generic timeout. 

This PR makes `hostmgr` retry while SSH is starting up, and tells us when macOS is blocking Local Network access.

See the [reported startup failure](https://a8c.slack.com/archives/C020Q0Z579V/p1789070774611399).